### PR TITLE
(Chore) Filter vestigingen

### DIFF
--- a/app/containers/withSelector/saga.js
+++ b/app/containers/withSelector/saga.js
@@ -163,7 +163,7 @@ export function* fetchKadastraalSubjectData(isNatuurlijkPersoon) {
 }
 
 export function* fetchVestigingData() {
-  const brkObjectIds = yield select(selectors.makeSelectFromObject('id'));
+  const brkObjectIds = yield select(selectors.makeSelectFromObjectAppartment('id'));
 
   try {
     if (brkObjectIds && brkObjectIds.length) {

--- a/app/containers/withSelector/selectors.js
+++ b/app/containers/withSelector/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
-import { formatData, isArray, isObject, isValidSubjectNP, isValidSubjectNNP } from 'utils';
+import { formatData, isArray, isObject, isValidSubjectNP, isValidSubjectNNP, isAppartment } from 'utils';
 import messages from 'containers/App/messages';
 
 export const selectBAG = state => state.bag;
@@ -229,6 +229,23 @@ export const makeSelectKadastraalSubjectNNPData = () =>
       }
 
       return results;
+    },
+  );
+
+export const makeSelectFromObjectAppartment = key =>
+  createSelector(
+    selectKadastraalObject,
+    state => {
+      const { data: { results } = {} } = state;
+
+      if (!results || !isArray(results) || !results.length) {
+        return undefined;
+      }
+
+      return results
+        .filter(isAppartment)
+        .map(item => item[key])
+        .filter(Boolean);
     },
   );
 

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -6,6 +6,16 @@ const dateFields = ['begin_geldigheid', 'document_mutatie', 'einde_geldigheid', 
 const currencyFields = ['koopsom'];
 
 /**
+ * Kadastraal object nummer regular expression
+ */
+export const reKadastraalObjectNr = /([A-Z]{3}\d{2})\s?([A-Z]{1,2})\s?(\d{4,5})\s?(A|G)\s?(\d{1,4})/;
+
+/**
+ * Kadastraal object nummer regular expression with groups
+ */
+export const reKadastraalObjectNrGroups = /(?<gemeente>[A-Z]{3}\d{2})\s?(?<sectie>[A-Z]{1,2})\s?(?<objectNummer>\d{4,5})\s?(?<indexLetter>A|G)\s?(?<indexNummer>\d{1,4})/;
+
+/**
  * Object detector
  *
  * @param {Any} value
@@ -202,9 +212,4 @@ export const isValidSubjectNP = ({ geboortedatum, naam }) => !!geboortedatum && 
 
 export const isValidSubjectNNP = ({ kvknummer, rsin }) => !!kvknummer && !!rsin;
 
-const reKadastraalObjectNr = /[A-Z]{3}\d{2}\s?[A-Z]\s?\d{4,5}\s?(A|G)\s?\d{1,4}/;
-
-export const isAppartment = ({ aanduiding }) => {
-  const [, indexLetter] = aanduiding.match(reKadastraalObjectNr);
-  return indexLetter.toLowerCase() === 'a';
-};
+export const isAppartment = ({ indexletter }) => indexletter.toLowerCase() === 'a';

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -201,3 +201,10 @@ export const formatData = ({ data, keys, locale = 'default' }) => {
 export const isValidSubjectNP = ({ geboortedatum, naam }) => !!geboortedatum && !!naam;
 
 export const isValidSubjectNNP = ({ kvknummer, rsin }) => !!kvknummer && !!rsin;
+
+const reKadastraalObjectNr = /[A-Z]{3}\d{2}\s?[A-Z]\s?\d{4,5}\s?(A|G)\s?\d{1,4}/;
+
+export const isAppartment = ({ aanduiding }) => {
+  const [, indexLetter] = aanduiding.match(reKadastraalObjectNr);
+  return indexLetter.toLowerCase() === 'a';
+};


### PR DESCRIPTION
This PR contains a change that makes sure that only vestigingen are shown that belong to an appartment and not the ground on which the kadastraal object is built.