### PR TITLE
(Fix) Progress component position

### DIFF
--- a/app/components/Progress/index.js
+++ b/app/components/Progress/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, createRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { determined, undetermined, label as labelStyles } from './styles';
@@ -21,9 +21,32 @@ const Label = styled.div`
  */
 const Progress = ({ className, label, labelPosition, showLabel, variant, ...props }) => {
   const scaleFactor = variant === 'small' ? 0.333 : 1;
+  const progressRef = createRef();
+
+  useEffect(() => {
+    const { current } = progressRef;
+
+    const removeNode = ({ currentTarget }) => {
+      if (currentTarget.classList.contains('finished')) {
+        currentTarget.classList.add('hidden');
+      }
+    };
+
+    current.addEventListener('transitionend', removeNode, true);
+
+    return () => {
+      current.removeEventListener('transitionend', removeNode);
+    };
+  });
 
   return (
-    <Wrapper className={`${className}${props.now >= 1 ? ' finished' : ''}`} scaleFactor={scaleFactor} {...props}>
+    <Wrapper
+      ref={progressRef}
+      className={`no-print ${className}${props.now >= 1 ? ' finished' : ''}`}
+      scaleFactor={scaleFactor}
+      as="div"
+      {...props}
+    >
       <Pie key={Math.random()} {...props} scaleFactor={scaleFactor} />
       {showLabel && (
         <Label vPos={labelPosition}>{label !== undefined ? label : `${Math.round(props.now * 100)} %`}</Label>

--- a/app/components/Progress/styles.js
+++ b/app/components/Progress/styles.js
@@ -23,11 +23,16 @@ const wrapper = css`
           box-sizing: content-box;
           transition: transform 0.35s ease-out;
           transform: translate3D(0, ${({ now }) => (now >= 1 ? -120 : 0)}px, 0);
+          top: 0;
 
           &.finished {
             transition-delay: 0.7s;
           }
         `}
+
+  &.hidden {
+    display: none;
+  }
 `;
 
 export const determined = {

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -23,6 +23,7 @@ import OpenbareRuimte from 'containers/OpenbareRuimte';
 import Gebied from 'containers/Gebied';
 import Summary from 'containers/Summary';
 import Woonplaats from 'containers/Woonplaats';
+import Progress from 'containers/Progress';
 
 import TOC from 'containers/TOC';
 import Map from 'containers/Map';
@@ -30,7 +31,7 @@ import Map from 'containers/Map';
 import { ArticleHeading, SectionHeading, Textarea, Aside } from './styled';
 
 const Wrapper = styled.div`
-  @media (max-width: 920px) {
+  @media screen and (max-width: 920px) {
     flex-direction: column;
 
     & > * {
@@ -99,6 +100,7 @@ export class AccommodationObjectPageComponent extends Component {
 
     return (
       <Wrapper className="row justify-content-lg-between content-md-between">
+        <Progress />
         <article className="col-7">
           <section>
             <header>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -11,7 +11,6 @@ import Footer from 'components/Footer';
 import Header from 'containers/Header/Loadable';
 import GlobalError from 'containers/GlobalError';
 import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
-import Progress from 'containers/Progress';
 import Search from 'containers/Search';
 
 import { ThemeProvider } from '@datapunt/asc-ui';
@@ -33,7 +32,6 @@ export const App = ({ onAuthenticateUser, showError }) => {
   return (
     <ThemeProvider>
       <div className="container app-container">
-        <Progress />
         <Header />
         <Search />
         <GlobalError />


### PR DESCRIPTION
This PR:
- moves the Progress container component out of the `App` container and into the `AccommodationObjectPage` container
- makes sure the `Progress` component is hidden when it is moved off-screen