### PR TITLE
(Fix) Remove repo.data.amsterdam.nl from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com:
 COPY package.json package-lock.json /deploy/
 COPY internals /deploy/internals/
 
-RUN npm config set registry https://repo.data.amsterdam.nl/repository/npm-group/ && \
-    npm --production=false \
+# RUN npm config set registry https://repo.data.amsterdam.nl/repository/npm-group/ && \
+RUN npm --production=false \
         --unsafe-perm \
         --verbose \
         ci && \


### PR DESCRIPTION
Since the acc and prod instances don't have a URL available for them yet, we cannot get NPM packages from the amsterdam registry. This PR removes the line that sets the registry.