### PR TITLE
(Chore) 'registraties' client id

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -12,10 +12,12 @@ import Header from 'containers/Header/Loadable';
 import GlobalError from 'containers/GlobalError';
 import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
 import Search from 'containers/Search';
+import injectSaga from 'utils/injectSaga';
 
 import { ThemeProvider } from '@datapunt/asc-ui';
 
 import { showGlobalError, authenticateUser } from './actions';
+import saga from './saga';
 
 import GlobalStyles from '../../global-styles';
 
@@ -72,4 +74,7 @@ const withConnect = connect(
   mapDispatchToProps,
 );
 
-export default compose(withConnect)(App);
+export default compose(
+  withConnect,
+  injectSaga({ key: 'global', saga }),
+)(App);

--- a/app/shared/services/auth/auth.js
+++ b/app/shared/services/auth/auth.js
@@ -45,7 +45,7 @@ const scopes = [
   // Handelsregister
   'HR/R', // Leesrechten
 ];
-const clientId = 'citydata';
+const clientId = 'registraties';
 
 const domainList = ['datapunt', 'grip'];
 


### PR DESCRIPTION
This PR:
- sets the correct client id for the authentication service
- inject the global saga in the `App` container so that login and logout buttons work