### PR TITLE
(Fix) Account for no BRK

### DIFF
--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -20,7 +20,7 @@ import CSVDownloadContainer from 'containers/CSVDownload';
 import TOC from 'containers/TOC';
 import Map from 'containers/Map';
 import messages from 'containers/App/messages';
-import { LOAD_DATA_SUCCESS } from 'containers/App/constants';
+import { LOAD_DATA_SUCCESS, LOAD_DATA_FAILED } from 'containers/App/constants';
 import SectionHeading from 'components/SectionHeading';
 import ArticleHeading from 'components/ArticleHeading';
 
@@ -111,13 +111,17 @@ class AccommodationObjectComponent extends React.Component {
         </article>
 
         <Aside className="col-4">
-          <section>
-            <TOC />
-          </section>
+          {status !== LOAD_DATA_FAILED && (
+            <>
+              <section>
+                <TOC />
+              </section>
 
-          <section>
-            <Summary />
-          </section>
+              <section>
+                <Summary />
+              </section>
+            </>
+          )}
 
           <Map marker search={false} zoom={14} />
 

--- a/app/containers/AccommodationObjectPage/saga.js
+++ b/app/containers/AccommodationObjectPage/saga.js
@@ -18,6 +18,9 @@ import { LOAD_BAG_DATA } from 'containers/App/constants';
 import { loadDataNoResults as loadKadastraalObjectDataNoResults } from 'containers/KadastraalObject/actions';
 import { loadDataNoResults as loadKadastraalSubjectNPDataNoResults } from 'containers/KadastraalSubjectNP/actions';
 import { loadDataNoResults as loadKadastraalSubjectNNPDataNoResults } from 'containers/KadastraalSubjectNNP/actions';
+import { loadDataNoResults as loadNummeraanduidingDataNoResults } from 'containers/Nummeraanduiding/actions';
+import { loadDataNoResults as loadWoonplaatsDataNoResults } from 'containers/Woonplaats/actions';
+import { loadDataNoResults as loadOpenbareRuimteDataNoResults } from 'containers/OpenbareRuimte/actions';
 
 import { fetchKadastraalObjectData } from 'containers/KadastraalObject/saga';
 import { fetchKadastraalSubjectNNPData } from 'containers/KadastraalSubjectNNP/saga';
@@ -73,15 +76,28 @@ export function* fetchData(action) {
       yield put(loadKadastraalSubjectNNPDataNoResults());
 
       nummeraanduidingId = yield select(makeSelectLIGNummeraanduidingId());
+    } else {
+      yield put(maxProgressCount(7));
     }
 
-    yield call(fetchNummeraanduidingData, nummeraanduidingId);
-    yield call(fetchWoonplaatsData);
+    if (!nummeraanduidingId) {
+      yield put(loadKadastraalObjectDataNoResults());
+      yield put(loadKadastraalSubjectNPDataNoResults());
+      yield put(loadKadastraalSubjectNNPDataNoResults());
+      yield put(loadNummeraanduidingDataNoResults());
+      yield put(loadWoonplaatsDataNoResults());
+      yield put(loadOpenbareRuimteDataNoResults());
 
-    const oprId = yield select(makeSelectOpenbareRuimteId());
-    yield call(fetchOpenbareRuimteData, oprId);
+      yield put(showGlobalError('no_data_available'));
+    } else {
+      yield call(fetchNummeraanduidingData, nummeraanduidingId);
+      yield call(fetchWoonplaatsData);
 
-    yield put(statusSuccess());
+      const oprId = yield select(makeSelectOpenbareRuimteId());
+      yield call(fetchOpenbareRuimteData, oprId);
+
+      yield put(statusSuccess());
+    }
   } catch (error) {
     if (error.message === 'Failed to fetch') {
       // unable to fetch

--- a/app/containers/GlobalError/messages.js
+++ b/app/containers/GlobalError/messages.js
@@ -23,4 +23,7 @@ export default defineMessages({
   resource_not_found: {
     id: `${scope}.resource_not_found`,
   },
+  no_data_available: {
+    id: `${scope}.no_data_available`,
+  },
 });

--- a/app/containers/KadastraalObject/reducer.js
+++ b/app/containers/KadastraalObject/reducer.js
@@ -25,6 +25,7 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
 

--- a/app/containers/KadastraalObject/saga.js
+++ b/app/containers/KadastraalObject/saga.js
@@ -14,10 +14,15 @@ const BRK_OBJECT_API = `${API_ROOT}brk/object-expand/?verblijfsobjecten__id=`;
 export function* fetchKadastraalObjectData(adresseerbaarObjectId) {
   try {
     const data = yield call(request, `${BRK_OBJECT_API}${adresseerbaarObjectId}`, getRequestOptions());
-    const { count } = data;
 
-    if (count && count > 0) {
-      yield put(loadDataSuccess(data));
+    if (data) {
+      const { count } = data;
+
+      if (count && count > 0) {
+        yield put(loadDataSuccess(data));
+      } else {
+        yield put(loadDataNoResults());
+      }
     } else {
       yield put(loadDataNoResults());
     }

--- a/app/containers/KadastraalSubjectNNP/reducer.js
+++ b/app/containers/KadastraalSubjectNNP/reducer.js
@@ -25,6 +25,7 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
 

--- a/app/containers/KadastraalSubjectNNP/saga.js
+++ b/app/containers/KadastraalSubjectNNP/saga.js
@@ -17,10 +17,14 @@ export function* fetchKadastraalSubjectNNPData() {
     if (rechten) {
       const data = yield all([...rechten.map(link => call(request, link, getRequestOptions()))]);
 
-      const validEntities = data.filter(isValidSubjectNNP);
+      if (data) {
+        const validEntities = data.filter(isValidSubjectNNP);
 
-      if (validEntities && validEntities.length) {
-        yield put(loadDataSuccess(data));
+        if (validEntities && validEntities.length) {
+          yield put(loadDataSuccess(data));
+        } else {
+          yield put(loadDataNoResults());
+        }
       } else {
         yield put(loadDataNoResults());
       }

--- a/app/containers/KadastraalSubjectNP/reducer.js
+++ b/app/containers/KadastraalSubjectNP/reducer.js
@@ -25,6 +25,7 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
 

--- a/app/containers/KadastraalSubjectNP/saga.js
+++ b/app/containers/KadastraalSubjectNP/saga.js
@@ -18,10 +18,14 @@ export function* fetchKadastraalSubjectNPData() {
     if (rechten) {
       const data = yield all([...rechten.map(link => call(request, link, getRequestOptions()))]);
 
-      const validEntities = data.filter(isValidSubjectNP);
+      if (data) {
+        const validEntities = data.filter(isValidSubjectNP);
 
-      if (validEntities && validEntities.length) {
-        yield put(loadDataSuccess(data));
+        if (validEntities && validEntities.length) {
+          yield put(loadDataSuccess(data));
+        } else {
+          yield put(loadDataNoResults());
+        }
       } else {
         yield put(loadDataNoResults());
       }

--- a/app/containers/Ligplaats/actions.js
+++ b/app/containers/Ligplaats/actions.js
@@ -1,4 +1,4 @@
-import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS } from './constants';
+import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS, LOAD_DATA_NO_RESULTS } from './constants';
 
 export const loadData = payload => ({
   type: LOAD_DATA,
@@ -12,5 +12,10 @@ export const loadDataSuccess = payload => ({
 
 export const loadDataFailed = payload => ({
   type: LOAD_DATA_FAILED,
+  payload,
+});
+
+export const loadDataNoResults = payload => ({
+  type: LOAD_DATA_NO_RESULTS,
   payload,
 });

--- a/app/containers/Ligplaats/constants.js
+++ b/app/containers/Ligplaats/constants.js
@@ -5,3 +5,4 @@ const containerScope = `${scope}/Ligplaats`;
 export const LOAD_DATA = `${containerScope}/LOAD_DATA`;
 export const LOAD_DATA_SUCCESS = `${containerScope}/LOAD_DATA_SUCCESS`;
 export const LOAD_DATA_FAILED = `${containerScope}/LOAD_DATA_FAILED`;
+export const LOAD_DATA_NO_RESULTS = `${containerScope}/LOAD_DATA_NO_RESULTS`;

--- a/app/containers/Ligplaats/reducer.js
+++ b/app/containers/Ligplaats/reducer.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 import { LOAD_DATA_PENDING } from 'containers/App/constants';
-import { LOAD_DATA_SUCCESS, LOAD_DATA_FAILED, LOAD_DATA } from './constants';
+import { LOAD_DATA_SUCCESS, LOAD_DATA_FAILED, LOAD_DATA, LOAD_DATA_NO_RESULTS } from './constants';
 
 export const initialState = {
   data: undefined,
@@ -25,7 +25,11 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
+
+      case LOAD_DATA_NO_RESULTS:
+        draft.data = null;
     }
   });

--- a/app/containers/Ligplaats/saga.js
+++ b/app/containers/Ligplaats/saga.js
@@ -6,7 +6,7 @@ import configuration from 'shared/services/configuration/configuration';
 import { incrementProgress } from 'containers/App/actions';
 
 import { LOAD_DATA } from './constants';
-import { loadDataSuccess, loadDataFailed } from './actions';
+import { loadDataSuccess, loadDataFailed, loadDataNoResults } from './actions';
 
 const { API_ROOT } = configuration;
 const LIGPLAATS_API = `${API_ROOT}bag/ligplaats/`;
@@ -15,7 +15,11 @@ export function* fetchLigplaatsData(ligplaatsId) {
   try {
     const data = yield call(request, `${LIGPLAATS_API}${ligplaatsId}/`, getRequestOptions());
 
-    yield put(loadDataSuccess(data));
+    if (data) {
+      yield put(loadDataSuccess(data));
+    } else {
+      yield put(loadDataNoResults());
+    }
   } catch (error) {
     yield put(loadDataFailed(error));
     throw error;

--- a/app/containers/Nummeraanduiding/actions.js
+++ b/app/containers/Nummeraanduiding/actions.js
@@ -1,4 +1,4 @@
-import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS } from './constants';
+import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS, LOAD_DATA_NO_RESULTS } from './constants';
 
 export const loadData = nummeraanduidingId => ({
   type: LOAD_DATA,
@@ -12,5 +12,10 @@ export const loadDataSuccess = payload => ({
 
 export const loadDataFailed = payload => ({
   type: LOAD_DATA_FAILED,
+  payload,
+});
+
+export const loadDataNoResults = payload => ({
+  type: LOAD_DATA_NO_RESULTS,
   payload,
 });

--- a/app/containers/Nummeraanduiding/constants.js
+++ b/app/containers/Nummeraanduiding/constants.js
@@ -5,3 +5,4 @@ const containerScope = `${scope}/Nummeraanduioding`;
 export const LOAD_DATA = `${containerScope}/LOAD_DATA`;
 export const LOAD_DATA_SUCCESS = `${containerScope}/LOAD_DATA_SUCCESS`;
 export const LOAD_DATA_FAILED = `${containerScope}/LOAD_DATA_FAILED`;
+export const LOAD_DATA_NO_RESULTS = `${containerScope}/LOAD_DATA_NO_RESULTS`;

--- a/app/containers/Nummeraanduiding/reducer.js
+++ b/app/containers/Nummeraanduiding/reducer.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 import { LOAD_DATA_PENDING } from 'containers/App/constants';
-import { LOAD_DATA, LOAD_DATA_SUCCESS, LOAD_DATA_FAILED } from './constants';
+import { LOAD_DATA, LOAD_DATA_SUCCESS, LOAD_DATA_FAILED, LOAD_DATA_NO_RESULTS } from './constants';
 
 // The initial state of the App
 export const initialState = {
@@ -27,7 +27,12 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
+        break;
+
+      case LOAD_DATA_NO_RESULTS:
+        draft.data = null;
         break;
     }
   });

--- a/app/containers/Nummeraanduiding/saga.js
+++ b/app/containers/Nummeraanduiding/saga.js
@@ -4,7 +4,7 @@ import request from 'utils/request';
 import configuration from 'shared/services/configuration/configuration';
 import { incrementProgress } from 'containers/App/actions';
 
-import { loadDataSuccess, loadDataFailed } from './actions';
+import { loadDataSuccess, loadDataFailed, loadDataNoResults } from './actions';
 import { LOAD_DATA } from './constants';
 
 const { API_ROOT } = configuration;
@@ -14,7 +14,11 @@ export function* fetchNummeraanduidingData(nummeraanduidingId) {
   try {
     const data = yield call(request, `${NUMMERAANDUIDING_API}${nummeraanduidingId}/`);
 
-    yield put(loadDataSuccess(data));
+    if (data) {
+      yield put(loadDataSuccess(data));
+    } else {
+      yield put(loadDataNoResults());
+    }
   } catch (error) {
     yield put(loadDataFailed(error));
     throw error;

--- a/app/containers/OpenbareRuimte/actions.js
+++ b/app/containers/OpenbareRuimte/actions.js
@@ -1,4 +1,4 @@
-import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS } from './constants';
+import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS, LOAD_DATA_NO_RESULTS } from './constants';
 
 export const loadData = openbareRuimteId => ({
   type: LOAD_DATA,
@@ -12,5 +12,10 @@ export const loadDataSuccess = payload => ({
 
 export const loadDataFailed = payload => ({
   type: LOAD_DATA_FAILED,
+  payload,
+});
+
+export const loadDataNoResults = payload => ({
+  type: LOAD_DATA_NO_RESULTS,
   payload,
 });

--- a/app/containers/OpenbareRuimte/constants.js
+++ b/app/containers/OpenbareRuimte/constants.js
@@ -5,3 +5,4 @@ const containerScope = `${scope}/OpenbareRuimte`;
 export const LOAD_DATA = `${containerScope}/LOAD_DATA`;
 export const LOAD_DATA_SUCCESS = `${containerScope}/LOAD_DATA_SUCCESS`;
 export const LOAD_DATA_FAILED = `${containerScope}/LOAD_DATA_FAILED`;
+export const LOAD_DATA_NO_RESULTS = `${containerScope}/LOAD_DATA_NO_RESULTS`;

--- a/app/containers/OpenbareRuimte/reducer.js
+++ b/app/containers/OpenbareRuimte/reducer.js
@@ -1,7 +1,7 @@
 import produce from 'immer';
 import { LOAD_DATA_PENDING } from 'containers/App/constants';
 
-import { LOAD_DATA_FAILED, LOAD_DATA_SUCCESS } from './constants';
+import { LOAD_DATA_FAILED, LOAD_DATA_SUCCESS, LOAD_DATA_NO_RESULTS } from './constants';
 
 // The initial state of the App
 export const initialState = {
@@ -23,7 +23,12 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
+        break;
+
+      case LOAD_DATA_NO_RESULTS:
+        draft.data = null;
         break;
     }
   });

--- a/app/containers/OpenbareRuimte/saga.js
+++ b/app/containers/OpenbareRuimte/saga.js
@@ -5,7 +5,7 @@ import { getAuthHeaders } from 'shared/services/auth/auth';
 import configuration from 'shared/services/configuration/configuration';
 import { incrementProgress } from 'containers/App/actions';
 
-import { loadDataSuccess, loadDataFailed } from './actions';
+import { loadDataSuccess, loadDataFailed, loadDataNoResults } from './actions';
 import { LOAD_DATA } from './constants';
 
 const { API_ROOT } = configuration;
@@ -15,7 +15,11 @@ export function* fetchOpenbareRuimteData(openbareRuimteId) {
   try {
     const data = yield call(request, `${OPENBARE_RUIMTE_API}${openbareRuimteId}/`, getAuthHeaders());
 
-    yield put(loadDataSuccess(data));
+    if (data) {
+      yield put(loadDataSuccess(data));
+    } else {
+      yield put(loadDataNoResults());
+    }
   } catch (error) {
     yield put(loadDataFailed(error));
     throw error;

--- a/app/containers/Pand/actions.js
+++ b/app/containers/Pand/actions.js
@@ -1,11 +1,12 @@
 import {
-  LOAD_DATA,
   LOAD_DATA_FAILED,
+  LOAD_DATA_NO_RESULTS,
   LOAD_DATA_SUCCESS,
-  LOAD_LIST_DATA,
+  LOAD_DATA,
   LOAD_LIST_DATA_FAILED,
   LOAD_LIST_DATA_NO_RESULTS,
   LOAD_LIST_DATA_SUCCESS,
+  LOAD_LIST_DATA,
 } from './constants';
 
 export const loadData = landelijkId => ({
@@ -20,6 +21,11 @@ export const loadDataSuccess = payload => ({
 
 export const loadDataFailed = payload => ({
   type: LOAD_DATA_FAILED,
+  payload,
+});
+
+export const loadDataNoResults = payload => ({
+  type: LOAD_DATA_NO_RESULTS,
   payload,
 });
 

--- a/app/containers/Pand/constants.js
+++ b/app/containers/Pand/constants.js
@@ -5,6 +5,7 @@ const containerScope = `${scope}/Pand`;
 export const LOAD_DATA = `${containerScope}/LOAD_DATA`;
 export const LOAD_DATA_SUCCESS = `${containerScope}/LOAD_DATA_SUCCESS`;
 export const LOAD_DATA_FAILED = `${containerScope}/LOAD_DATA_FAILED`;
+export const LOAD_DATA_NO_RESULTS = `${containerScope}/LOAD_DATA_NO_RESULTS`;
 
 export const LOAD_LIST_DATA = `${containerScope}/LOAD_LIST_DATA`;
 export const LOAD_LIST_DATA_SUCCESS = `${containerScope}/LOAD_LIST_DATA_SUCCESS`;

--- a/app/containers/Pand/reducer.js
+++ b/app/containers/Pand/reducer.js
@@ -1,7 +1,7 @@
 import produce from 'immer';
 
 import { LOAD_DATA_PENDING } from 'containers/App/constants';
-import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS } from './constants';
+import { LOAD_DATA, LOAD_DATA_FAILED, LOAD_DATA_SUCCESS, LOAD_DATA_NO_RESULTS } from './constants';
 
 // The initial state of the App
 export const initialState = {
@@ -28,7 +28,12 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
+        break;
+
+      case LOAD_DATA_NO_RESULTS:
+        draft.data = null;
         break;
     }
   });

--- a/app/containers/Pand/saga.js
+++ b/app/containers/Pand/saga.js
@@ -11,6 +11,7 @@ import {
   loadlistDataFailed,
   loadDataSuccess,
   loadDataFailed,
+  loadDataNoResults,
 } from './actions';
 
 const { API_ROOT } = configuration;
@@ -38,7 +39,11 @@ export function* fetchPandData(landelijkId) {
   try {
     const data = yield call(request, `${PAND_API}${landelijkId}/`);
 
-    yield put(loadDataSuccess(data));
+    if (data) {
+      yield put(loadDataSuccess(data));
+    } else {
+      yield put(loadDataNoResults());
+    }
   } catch (error) {
     yield put(loadDataFailed(error));
     throw error;

--- a/app/containers/Verblijfsobject/index.js
+++ b/app/containers/Verblijfsobject/index.js
@@ -10,8 +10,6 @@ import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
 import { OBJECTS, LOAD_DATA_FAILED } from 'containers/App/constants';
 import { makeSelectStatus } from 'containers/App/selectors';
-import ligplaatsSaga from 'containers/Ligplaats/saga';
-import ligplaatsReducer from 'containers/Ligplaats/reducer';
 
 import { makeSelectVerblijfsobjectData } from './selectors';
 import saga from './saga';
@@ -56,6 +54,4 @@ export default compose(
   withConnect,
   injectSaga({ key: 'verblijfsobject', saga }),
   injectReducer({ key: 'verblijfsobject', reducer }),
-  injectSaga({ key: 'ligplaats', saga: ligplaatsSaga }),
-  injectReducer({ key: 'ligplaats', reducer: ligplaatsReducer }),
 )(memo(Intl));

--- a/app/containers/Verblijfsobject/reducer.js
+++ b/app/containers/Verblijfsobject/reducer.js
@@ -27,6 +27,7 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
     }

--- a/app/containers/Verblijfsobject/selectors.js
+++ b/app/containers/Verblijfsobject/selectors.js
@@ -51,7 +51,7 @@ export const makeSelectVBONummeraanduidingId = () =>
       const { data } = state;
 
       if (!data) {
-        return undefined;
+        return data;
       }
 
       return data.hoofdadres.landelijk_id;

--- a/app/containers/Vestiging/reducer.js
+++ b/app/containers/Vestiging/reducer.js
@@ -20,11 +20,12 @@ export default (state = initialState, action) =>
         break;
 
       case LOAD_DATA_FAILED:
+        draft.data = null;
         draft.error = action.payload;
         break;
 
       case LOAD_DATA_NO_RESULTS:
-        draft.data = undefined;
+        draft.data = null;
         break;
     }
   });

--- a/app/containers/Vestiging/saga.js
+++ b/app/containers/Vestiging/saga.js
@@ -28,6 +28,8 @@ export function* fetchVestigingData() {
       } else {
         yield put(loadDataSuccess(data));
       }
+    } else {
+      yield put(loadDataNoResults());
     }
   } catch (error) {
     yield put(loadDataFailed());

--- a/app/containers/Woonplaats/reducer.js
+++ b/app/containers/Woonplaats/reducer.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 import { LOAD_DATA_PENDING } from 'containers/App/constants';
-import { LOAD_DATA_SUCCESS, LOAD_DATA_FAILED } from './constants';
+import { LOAD_DATA_SUCCESS, LOAD_DATA_FAILED, LOAD_DATA_NO_RESULTS } from './constants';
 
 // The initial state of the App
 export const initialState = {
@@ -23,6 +23,10 @@ export default (state = initialState, action) =>
 
       case LOAD_DATA_FAILED:
         draft.error = action.payload;
+        break;
+
+      case LOAD_DATA_NO_RESULTS:
+        draft.data = null;
         break;
     }
   });

--- a/app/containers/Woonplaats/saga.js
+++ b/app/containers/Woonplaats/saga.js
@@ -22,7 +22,11 @@ export function* fetchWoonplaatsData() {
   try {
     const data = yield call(request, `${WOONPLAATS_API}${woonplaatsId}/`);
 
-    yield put(loadDataSuccess(data));
+    if (data) {
+      yield put(loadDataSuccess(data));
+    } else {
+      yield put(loadDataNoResults());
+    }
   } catch (error) {
     yield put(loadDataFailed(error));
     throw error;

--- a/app/translations/nl.json
+++ b/app/translations/nl.json
@@ -51,5 +51,6 @@
   "registraties.server_error": "Er is een fout opgetreden op de server. Niet alle gegevens uit de databronnen kunnen opgehaald worden. Probeer het over een paar minuten nogmaals.",
   "registraties.service_unavailable": "Een van de databronnen is niet beschikbaar. Probeer het over een paar minuten nogmaals.",
   "registraties.filled_in_by": "Ingevuld door",
-  "registraties.resource_not_found": "Een of meerdere databronnen zijn niet beschikbaar of retourneerden geen gegevens. Controleer de URL of probeer het over enkele minuten nogmaals."
+  "registraties.resource_not_found": "Een of meerdere databronnen zijn niet beschikbaar of retourneerden geen gegevens. Controleer de URL of probeer het over enkele minuten nogmaals.",
+  "registraties.no_data_available": "Er konden geen relevante gegevens gevonden worden"
 }


### PR DESCRIPTION
This PR contains changes to actions, reducers and sagas that make sure that, when there is no data retrieved from one of the endpoints, the application's interface degraces gracefully by not showing loading spinners and, when crucial data (kadastraal object) cannot be found, a proper error message is displayed.