### PR TITLE
(Fix) Env root

### DIFF
--- a/environment.conf.json
+++ b/environment.conf.json
@@ -1,5 +1,5 @@
 {
   "API_ROOT": "https://acc.api.data.amsterdam.nl/",
-  "ROOT": "http://localhost:8080/",
+  "ROOT": "/",
   "AUTH_ROOT": "https://acc.api.data.amsterdam.nl/"
 }

--- a/environment.conf.prod.json
+++ b/environment.conf.prod.json
@@ -1,5 +1,5 @@
 {
   "API_ROOT": "https://api.data.amsterdam.nl/",
-  "ROOT": "https://registraties.amsterdam.nl/",
+  "ROOT": "/",
   "AUTH_ROOT": "https://api.data.amsterdam.nl/"
 }


### PR DESCRIPTION
Changes the root URL to `/` to prevent conflicts between environments. Mainly between `acc` and `prod`.