### PR TITLE
(Fix) IE11 issues

### DIFF
--- a/app/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/app/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -363,6 +363,7 @@ exports[`Header matches the snapshot 1`] = `
                   type="button"
                 >
                   <img
+                    focusable="false"
                     width="20"
                   />
                   <span>
@@ -376,6 +377,7 @@ exports[`Header matches the snapshot 1`] = `
                   type="button"
                 >
                   <img
+                    focusable="false"
                     width="20"
                   />
                   <span>
@@ -436,6 +438,7 @@ exports[`Header matches the snapshot 2`] = `
                   type="button"
                 >
                   <img
+                    focusable="false"
                     width="20"
                   />
                   <span>

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -86,13 +86,13 @@ const Header = ({ isAuthenticated, intl, onLoginLogoutButtonClick }) => (
             <>
               <li>
                 <button className="login" type="button" onClick={event => onLoginLogoutButtonClick(event, 'datapunt')}>
-                  <LoginIcon width={20} />
+                  <LoginIcon focusable="false" width={20} />
                   <span>{intl.formatMessage(messages.log_in)}</span>
                 </button>
               </li>
               <li>
                 <button className="login-adw" type="button" onClick={event => onLoginLogoutButtonClick(event, 'grip')}>
-                  <LoginIcon width={20} />
+                  <LoginIcon focusable="false" width={20} />
                   <span>{intl.formatMessage(messages.log_in_adw)}</span>
                 </button>
               </li>
@@ -101,7 +101,7 @@ const Header = ({ isAuthenticated, intl, onLoginLogoutButtonClick }) => (
           {isAuthenticated ? (
             <li>
               <button type="button" onClick={onLoginLogoutButtonClick}>
-                <LogoutIcon width={20} />
+                <LogoutIcon focusable="false" width={20} />
                 <span>{intl.formatMessage(messages.log_out)}</span>
               </button>
             </li>

--- a/app/components/Link/__tests__/__snapshots__/Link.test.js.snap
+++ b/app/components/Link/__tests__/__snapshots__/Link.test.js.snap
@@ -58,6 +58,7 @@ exports[`Link matches the snapshot 1`] = `
 >
   <img
     class="c2"
+    focusable="false"
     width="14"
   />
   <span

--- a/app/components/Link/index.js
+++ b/app/components/Link/index.js
@@ -25,7 +25,7 @@ const StyledIcon = styled(ChevronRight)`
 
 const Link = ({ href, onClick, className, label, ...rest }) => (
   <StyledT element="a" href={href} onClick={onClick} className={className} {...rest}>
-    <StyledIcon width={14} />
+    <StyledIcon focusable="false" width={14} />
     <span className="linklabel">{label}</span>
   </StyledT>
 );

--- a/app/components/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/app/components/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -155,6 +155,7 @@ exports[`Search matches the snapshot 1`] = `
     >
       <img
         data-testid="searchToggle-search-icon"
+        focusable="false"
         width="20"
       />
       <span
@@ -420,6 +421,12 @@ exports[`Search should render results 1`] = `
   color: #ec0000;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c10 a {
+    height: 26px;
+  }
+}
+
 @media (max-width:1200px) {
   .c0 {
     padding-top: 100px;
@@ -458,6 +465,7 @@ exports[`Search should render results 1`] = `
     >
       <img
         data-testid="searchToggle-search-icon"
+        focusable="false"
         width="20"
       />
       <span
@@ -519,6 +527,7 @@ exports[`Search should render results 1`] = `
                 >
                   <img
                     class="c15"
+                    focusable="false"
                     width="14"
                   />
                   <span
@@ -536,6 +545,7 @@ exports[`Search should render results 1`] = `
                 >
                   <img
                     class="c15"
+                    focusable="false"
                     width="14"
                   />
                   <span

--- a/app/components/SearchToggle/__tests__/__snapshots__/SearchToggle.test.js.snap
+++ b/app/components/SearchToggle/__tests__/__snapshots__/SearchToggle.test.js.snap
@@ -30,6 +30,7 @@ exports[`SearchToggle matches the snapshot 1`] = `
 >
   <img
     data-testid="searchToggle-search-icon"
+    focusable="false"
     width="20"
   />
   <span
@@ -49,6 +50,7 @@ exports[`SearchToggle matches the snapshot 2`] = `
 >
   <img
     data-testid="searchToggle-close-icon"
+    focusable="false"
     width="20"
   />
   <span

--- a/app/components/SearchToggle/index.js
+++ b/app/components/SearchToggle/index.js
@@ -29,9 +29,9 @@ const StyledIcon = styled.button`
 const SearchToggle = ({ active, onClick, className, label, ...rest }) => (
   <StyledIcon size={20} padding={0} className={className} onClick={onClick} type="button" {...rest}>
     {active ? (
-      <CloseIcon data-testid="searchToggle-close-icon" width={20} />
+      <CloseIcon data-testid="searchToggle-close-icon" focusable="false" width={20} />
     ) : (
-      <SearchIcon data-testid="searchToggle-search-icon" width={20} />
+      <SearchIcon data-testid="searchToggle-search-icon" focusable="false" width={20} />
     )}
     <span className="visuallyhidden" data-testid="searchToggle-label">
       {label}

--- a/app/components/Suggest/__tests__/__snapshots__/Suggest.test.js.snap
+++ b/app/components/Suggest/__tests__/__snapshots__/Suggest.test.js.snap
@@ -135,6 +135,12 @@ exports[`Suggest matches the snapshot 1`] = `
   color: #ec0000;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 a {
+    height: 26px;
+  }
+}
+
 <ul
   class=" links c0"
 >
@@ -155,6 +161,7 @@ exports[`Suggest matches the snapshot 1`] = `
         >
           <img
             class="c5"
+            focusable="false"
             width="14"
           />
           <span
@@ -172,6 +179,7 @@ exports[`Suggest matches the snapshot 1`] = `
         >
           <img
             class="c5"
+            focusable="false"
             width="14"
           />
           <span
@@ -189,6 +197,7 @@ exports[`Suggest matches the snapshot 1`] = `
         >
           <img
             class="c5"
+            focusable="false"
             width="14"
           />
           <span

--- a/app/components/Suggest/index.js
+++ b/app/components/Suggest/index.js
@@ -20,6 +20,12 @@ const Ul = styled.ul`
   li:first-of-type {
     margin-top: 8px !important;
   }
+
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    a {
+      height: 26px;
+    }
+  }
 `;
 
 /* eslint-disable indent,react/jsx-indent */

--- a/app/components/TOC/__tests__/__snapshots__/TOC.test.js.snap
+++ b/app/components/TOC/__tests__/__snapshots__/TOC.test.js.snap
@@ -316,6 +316,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -334,6 +335,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -352,6 +354,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -370,6 +373,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -388,6 +392,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -406,6 +411,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -424,6 +430,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span
@@ -442,6 +449,7 @@ exports[`TOC matches the snapshot 1`] = `
       >
         <img
           class="c4"
+          focusable="false"
           width="14"
         />
         <span

--- a/app/containers/GlobalError/index.js
+++ b/app/containers/GlobalError/index.js
@@ -63,7 +63,7 @@ export const GlobalError = ({ error, errorMessage, intl, onClose }) => (
         <ErrorContainer>
           <P>{intl.formatMessage(errorMessages[errorMessage])}</P>
           <Button type="button" onClick={onClose}>
-            <CloseIcon width={14} fill="#fff" />
+            <CloseIcon focusable="false" width={14} fill="#fff" />
             <Label>{intl.formatMessage(appMessages.close)}</Label>
           </Button>
         </ErrorContainer>

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -5,8 +5,13 @@ const Img = styled.img`
   width: 100%;
 `;
 
+const Picture = styled.picture`
+  max-width: 100%;
+  width: 100%;
+`;
+
 const HomePage = () => (
-  <picture>
+  <Picture>
     <source
       media="(min-width: 700px)"
       srcSet="//www.amsterdam.nl/publish/pages/830657/herengracht_met_fietsenrekken_eis_940x264.jpg"
@@ -23,8 +28,8 @@ const HomePage = () => (
       media="(max-width: 220px)"
       srcSet="//www.amsterdam.nl/publish/pages/830657/220px/herengracht_met_fietsenrekken_eis_940x264.jpg"
     />
-    <Img src="//www.amsterdam.nl/publish/pages/830657/80px/herengracht_met_fietsenrekken_eis_940x264.jpg" alt="" />
-  </picture>
+    <Img srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" alt="" />
+  </Picture>
 );
 
 export default HomePage;

--- a/app/containers/Search/index.js
+++ b/app/containers/Search/index.js
@@ -21,15 +21,15 @@ const SearchContainer = props => {
   const [showSuggest, setShowSuggest] = useState(true);
 
   const setup = () => {
-    if (inputRef.current) inputRef.current.addEventListener('blur', onBlur, true);
-    if (suggestRef.current) suggestRef.current.addEventListener('blur', onBlur, true);
+    if (inputRef.current) inputRef.current.addEventListener('focusout', onFocusOut, true);
+    if (suggestRef.current) suggestRef.current.addEventListener('focusout', onFocusOut, true);
 
     document.addEventListener('click', onClick, true);
   };
 
   const teardown = () => {
-    if (inputRef.current) inputRef.current.removeEventListener('blur', onBlur);
-    if (suggestRef.current) suggestRef.current.removeEventListener('blur', onBlur);
+    if (inputRef.current) inputRef.current.removeEventListener('focusout', onFocusOut);
+    if (suggestRef.current) suggestRef.current.removeEventListener('focusout', onFocusOut);
 
     document.removeEventListener('click', onClick);
   };
@@ -40,7 +40,7 @@ const SearchContainer = props => {
     return teardown;
   }, [inputRef.current, suggestRef.current]);
 
-  const onBlur = event => {
+  const onFocusOut = event => {
     const { relatedTarget } = event;
     const { current: input } = inputRef;
     const { current: suggest } = suggestRef;

--- a/app/global-styles.js
+++ b/app/global-styles.js
@@ -75,6 +75,10 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  picture, main {
+    display: block;
+  }
+
   #app {
     min-height: 100%;
     min-width: 100%;

--- a/app/index.html
+++ b/app/index.html
@@ -26,6 +26,10 @@
     })();
   </script>
   <!-- End Matomo Code -->
+
+  <!--[if gt IE 10]><!-->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/picturefill/3.0.3/picturefill.min.js" integrity="sha256-iT+n/otuaeKCgxnASny7bxKeqCDbaV1M7VdX1ZRQtqg=" crossorigin="anonymous" async></script>
+  <!--[if gt IE 8]><!-->
 </head>
 
 <body class="with-sidebars">


### PR DESCRIPTION
This PR fixes the following issues in IE11:
- `<picture>` element not supported (included picturefill polyfill)
- `onBlur` event not having `relatedTarget` property; switched for `focusOut` event which does have that attribute
- SVG elements gaining focus on tabbing through the UI