### PR TITLE
(Chore) reorder sections

### DIFF
--- a/app/components/AccommodationObject/__tests__/AccommodationObject.test.js
+++ b/app/components/AccommodationObject/__tests__/AccommodationObject.test.js
@@ -53,6 +53,59 @@ describe('AccommodationObject', () => {
     }).not.toThrow();
   });
 
+  it('should not render section headings', () => {
+    const { rerender, queryByTestId } = render(
+      <ThemeProvider>
+        <Provider store={store}>
+          <IntlProvider locale="nl" messages={messages}>
+            <AccommodationObject intl={intl} loadBAGData={() => {}} match={match} />
+          </IntlProvider>
+        </Provider>
+      </ThemeProvider>,
+    );
+
+    expect(queryByTestId('accommodationObjectBAGHeader')).toBeNull();
+    expect(queryByTestId('accommodationObjectBRKHeader')).toBeNull();
+
+    rerender(
+      <ThemeProvider>
+        <Provider store={store}>
+          <IntlProvider locale="nl" messages={messages}>
+            <AccommodationObject
+              intl={intl}
+              loadBAGData={() => {}}
+              match={match}
+              status={LOAD_DATA_SUCCESS}
+              summary={{ house_id: { value: '' } }}
+            />
+          </IntlProvider>
+        </Provider>
+      </ThemeProvider>,
+    );
+
+    expect(queryByTestId('accommodationObjectBAGHeader')).not.toBeNull();
+    expect(queryByTestId('accommodationObjectBRKHeader')).toBeNull();
+
+    rerender(
+      <ThemeProvider>
+        <Provider store={store}>
+          <IntlProvider locale="nl" messages={messages}>
+            <AccommodationObject
+              intl={intl}
+              loadBAGData={() => {}}
+              match={match}
+              status={LOAD_DATA_SUCCESS}
+              summary={{ cadastral_object_nr: { value: '' } }}
+            />
+          </IntlProvider>
+        </Provider>
+      </ThemeProvider>,
+    );
+
+    expect(queryByTestId('accommodationObjectBAGHeader')).toBeNull();
+    expect(queryByTestId('accommodationObjectBRKHeader')).not.toBeNull();
+  });
+
   it('should call action that initiates data fetch', () => {
     const loadBAGData = jest.fn();
     const { vboId } = match.params;

--- a/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
+++ b/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccommodationObject should render without problems 1`] = `
-.c6 {
+.c5 {
   margin-top: 30px;
   margin-top: 0;
 }
@@ -47,11 +47,11 @@ exports[`AccommodationObject should render without problems 1`] = `
   display: none;
 }
 
-.c8 {
+.c7 {
   position: relative;
 }
 
-.c8.hidden {
+.c7.hidden {
   display: none;
 }
 
@@ -94,7 +94,7 @@ exports[`AccommodationObject should render without problems 1`] = `
   display: none;
 }
 
-.c9 {
+.c8 {
   height: 19.98px;
   width: 19.98px;
   border-radius: 50%;
@@ -111,15 +111,15 @@ exports[`AccommodationObject should render without problems 1`] = `
   margin: 0;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   background-color: #fff;
   content: '';
   height: 21.978px;
   position: absolute;
 }
 
-.c9::before {
+.c8::before {
   -webkit-animation: rotate 1.5s infinite ease 1.2s;
   animation: rotate 1.5s infinite ease 1.2s;
   border-radius: 21.978px 0 0 21.978px;
@@ -131,7 +131,7 @@ exports[`AccommodationObject should render without problems 1`] = `
   width: 10.3854375px;
 }
 
-.c9::after {
+.c8::after {
   -webkit-animation: rotate 1.5s infinite ease;
   animation: rotate 1.5s infinite ease;
   border-radius: 0 21.978px 21.978px 0;
@@ -170,11 +170,11 @@ exports[`AccommodationObject should render without problems 1`] = `
   justify-content: space-between;
 }
 
-.c10 {
+.c9 {
   padding-top: 50px;
 }
 
-.c7 {
+.c6 {
   display: inline-block;
   width: 18px;
   height: 18px;
@@ -191,28 +191,24 @@ exports[`AccommodationObject should render without problems 1`] = `
   margin-left: 15px;
 }
 
-.c7:hover {
+.c6:hover {
   background-color: #009dec;
   color: white;
 }
 
-.c5 {
+.c4 {
   position: relative;
 }
 
-.c11 {
+.c10 {
   height: 200px;
   width: 100%;
   position: relative;
   z-index: 0;
 }
 
-.c4 {
-  margin-top: 0;
-}
-
 @media print {
-  .c6 {
+  .c5 {
     margin-top: 0;
   }
 }
@@ -283,7 +279,7 @@ exports[`AccommodationObject should render without problems 1`] = `
 }
 
 @media print {
-  .c7 {
+  .c6 {
     display: none;
   }
 }
@@ -310,53 +306,16 @@ exports[`AccommodationObject should render without problems 1`] = `
     class="col-7"
   >
     <section>
-      <header>
-        <h2
-          class="c4"
-        >
-          BAG Objecten
-        </h2>
-      </header>
       <section
-        class="c5"
+        class="c4"
       >
         <h3
-          class="c6"
-          id="Openbare ruimte"
-        >
-          Openbare ruimte
-          <a
-            class="c7"
-            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-3/"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="Naar definitie van Openbare ruimte op Stelselpedia (opent in een nieuw venster)."
-          >
-            <span>
-              i
-            </span>
-          </a>
-        </h3>
-        <div
-          class="no-print  c8"
-          data-testid="progress-wrapper"
-          type="undetermined"
-        >
-          <div
-            class="c9"
-          />
-        </div>
-      </section>
-      <section
-        class="c5"
-      >
-        <h3
-          class="c6"
+          class="c5"
           id="Woonplaats"
         >
           Woonplaats
           <a
-            class="c7"
+            class="c6"
             href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse/"
             rel="noopener noreferrer"
             target="_blank"
@@ -368,29 +327,32 @@ exports[`AccommodationObject should render without problems 1`] = `
           </a>
         </h3>
         <div
-          class="no-print  c8"
+          class="no-print  c7"
           data-testid="progress-wrapper"
           type="undetermined"
         >
           <div
-            class="c9"
+            class="c8"
           />
         </div>
       </section>
       <section
-        class="c5"
+        class="c4"
+      />
+      <section
+        class="c4"
       >
         <h3
-          class="c6"
-          id="Nummeraanduiding"
+          class="c5"
+          id="Openbare ruimte"
         >
-          Nummeraanduiding
+          Openbare ruimte
           <a
-            class="c7"
-            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-2/"
+            class="c6"
+            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-3/"
             rel="noopener noreferrer"
             target="_blank"
-            title="Naar definitie van Nummeraanduiding op Stelselpedia (opent in een nieuw venster)."
+            title="Naar definitie van Openbare ruimte op Stelselpedia (opent in een nieuw venster)."
           >
             <span>
               i
@@ -398,40 +360,36 @@ exports[`AccommodationObject should render without problems 1`] = `
           </a>
         </h3>
         <div
-          class="no-print  c8"
+          class="no-print  c7"
           data-testid="progress-wrapper"
           type="undetermined"
         >
           <div
-            class="c9"
+            class="c8"
           />
         </div>
       </section>
       <section
-        class="c5"
+        class="c4"
       />
       <section
-        class="c5"
+        class="c4"
+      />
+      <section
+        class="c4"
       />
     </section>
     <section>
-      <header>
-        <h2
-          class=""
-        >
-          BRK Objecten
-        </h2>
-      </header>
       <section
-        class="c5"
+        class="c4"
       >
         <h3
-          class="c6"
+          class="c5"
           id="Kadastraal object"
         >
           Kadastraal object
           <a
-            class="c7"
+            class="c6"
             href="//www.amsterdam.nl/stelselpedia/brk-index/catalog-brk-levering/objectklasse-4/"
             rel="noopener noreferrer"
             target="_blank"
@@ -443,84 +401,54 @@ exports[`AccommodationObject should render without problems 1`] = `
           </a>
         </h3>
         <div
-          class="no-print  c8"
+          class="no-print  c7"
           data-testid="progress-wrapper"
           type="undetermined"
         >
           <div
-            class="c9"
+            class="c8"
           />
         </div>
       </section>
       <section
-        class="c5"
+        class="c4"
       />
       <section
-        class="c5"
+        class="c4"
       />
       <section
-        class="c5"
+        class="c4"
       />
-      <section
-        class="c5"
-      >
-        <h3
-          class="c6"
-          id="Gebied"
-        >
-          Gebied
-          <a
-            class="c7"
-            href="//www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="Naar definitie van Gebied op Stelselpedia (opent in een nieuw venster)."
-          >
-            <span>
-              i
-            </span>
-          </a>
-        </h3>
-        <div
-          class="no-print  c8"
-          data-testid="progress-wrapper"
-          type="undetermined"
-        >
-          <div
-            class="c9"
-          />
-        </div>
-      </section>
     </section>
   </article>
   <aside
-    class="col-4 c10"
+    class="col-4 c9"
   >
     <section>
       <div
-        class="no-print  c8"
+        class="no-print  c7"
         data-testid="progress-wrapper"
         type="undetermined"
       >
         <div
-          class="c9"
+          class="c8"
         />
       </div>
     </section>
     <section>
       <div
-        class="no-print  c8"
+        class="no-print  c7"
         data-testid="progress-wrapper"
         type="undetermined"
       >
         <div
-          class="c9"
+          class="c8"
         />
       </div>
     </section>
     <section>
       <div
-        class="cf c11"
+        class="cf c10"
       >
         <div
           id="mapDiv"
@@ -601,131 +529,6 @@ exports[`AccommodationObject should render without problems 2`] = `
     class="col-7"
   >
     <section>
-      <header>
-        <h2
-          class="ArticleHeading__H2-sc-1i8jimd-0 iXCxRu"
-        >
-          BAG Objecten
-        </h2>
-      </header>
-      <section
-        class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
-      >
-        .c0 {
-  margin-top: 30px;
-  margin-top: 0;
-}
-
-.c1 {
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  text-align: center;
-  line-height: 18px;
-  border-radius: 50%;
-  background-color: #b4b4b4;
-  color: white;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 12px;
-  cursor: pointer;
-  vertical-align: middle;
-  margin-left: 15px;
-}
-
-.c1:hover {
-  background-color: #009dec;
-  color: white;
-}
-
-@media print {
-  .c0 {
-    margin-top: 0;
-  }
-}
-
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-<h3
-          class="c0"
-          id="Openbare ruimte"
-        >
-          Openbare ruimte
-          <a
-            class="c1"
-            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-3/"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="Naar definitie van Openbare ruimte op Stelselpedia (opent in een nieuw venster)."
-          >
-            <span>
-              i
-            </span>
-          </a>
-        </h3>
-        <div
-          class="no-print  Progress__Wrapper-yfxggj-0 fHvQdR"
-          data-testid="progress-wrapper"
-          type="undetermined"
-        >
-          .c0 {
-  height: 19.98px;
-  width: 19.98px;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1.9980000000000002px;
-  color: #ec0000;
-  display: inline-block;
-  font-size: 1.9980000000000002px;
-  position: relative;
-  text-indent: -99999em;
-  -webkit-transform: translate3D(0,0,0);
-  -ms-transform: translate3D(0,0,0);
-  transform: translate3D(0,0,0);
-  vertical-align: middle;
-  margin: 0;
-}
-
-.c0::before,
-.c0::after {
-  background-color: #fff;
-  content: '';
-  height: 21.978px;
-  position: absolute;
-}
-
-.c0::before {
-  -webkit-animation: rotate 1.5s infinite ease 1.2s;
-  animation: rotate 1.5s infinite ease 1.2s;
-  border-radius: 21.978px 0 0 21.978px;
-  left: -0.9990000000000001px;
-  top: -0.9990000000000001px;
-  -webkit-transform-origin: 10.589400000000001px 10.989px;
-  -ms-transform-origin: 10.589400000000001px 10.989px;
-  transform-origin: 10.589400000000001px 10.989px;
-  width: 10.3854375px;
-}
-
-.c0::after {
-  -webkit-animation: rotate 1.5s infinite ease;
-  animation: rotate 1.5s infinite ease;
-  border-radius: 0 21.978px 21.978px 0;
-  left: 10.3854375px;
-  top: -0.5994px;
-  -webkit-transform-origin: -0.1998px 10.989px;
-  -ms-transform-origin: -0.1998px 10.989px;
-  transform-origin: -0.1998px 10.989px;
-  width: 11.186735400000002px;
-}
-
-<div
-            class="c0"
-          />
-        </div>
-      </section>
       <section
         class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
       >
@@ -846,6 +649,9 @@ exports[`AccommodationObject should render without problems 2`] = `
       </section>
       <section
         class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
+      />
+      <section
+        class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
       >
         .c0 {
   margin-top: 30px;
@@ -888,15 +694,15 @@ exports[`AccommodationObject should render without problems 2`] = `
 
 <h3
           class="c0"
-          id="Nummeraanduiding"
+          id="Openbare ruimte"
         >
-          Nummeraanduiding
+          Openbare ruimte
           <a
             class="c1"
-            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-2/"
+            href="//www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-3/"
             rel="noopener noreferrer"
             target="_blank"
-            title="Naar definitie van Nummeraanduiding op Stelselpedia (opent in een nieuw venster)."
+            title="Naar definitie van Openbare ruimte op Stelselpedia (opent in een nieuw venster)."
           >
             <span>
               i
@@ -968,15 +774,11 @@ exports[`AccommodationObject should render without problems 2`] = `
       <section
         class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
       />
+      <section
+        class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
+      />
     </section>
     <section>
-      <header>
-        <h2
-          class="ArticleHeading__H2-sc-1i8jimd-0 gjGWIG"
-        >
-          BRK Objecten
-        </h2>
-      </header>
       <section
         class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
       >
@@ -1104,124 +906,6 @@ exports[`AccommodationObject should render without problems 2`] = `
       <section
         class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
       />
-      <section
-        class="Section__SectionWrapper-sc-1jybffj-0 Dkpju"
-      >
-        .c0 {
-  margin-top: 30px;
-  margin-top: 0;
-}
-
-.c1 {
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  text-align: center;
-  line-height: 18px;
-  border-radius: 50%;
-  background-color: #b4b4b4;
-  color: white;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 12px;
-  cursor: pointer;
-  vertical-align: middle;
-  margin-left: 15px;
-}
-
-.c1:hover {
-  background-color: #009dec;
-  color: white;
-}
-
-@media print {
-  .c0 {
-    margin-top: 0;
-  }
-}
-
-@media print {
-  .c1 {
-    display: none;
-  }
-}
-
-<h3
-          class="c0"
-          id="Gebied"
-        >
-          Gebied
-          <a
-            class="c1"
-            href="//www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="Naar definitie van Gebied op Stelselpedia (opent in een nieuw venster)."
-          >
-            <span>
-              i
-            </span>
-          </a>
-        </h3>
-        <div
-          class="no-print  Progress__Wrapper-yfxggj-0 fHvQdR"
-          data-testid="progress-wrapper"
-          type="undetermined"
-        >
-          .c0 {
-  height: 19.98px;
-  width: 19.98px;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1.9980000000000002px;
-  color: #ec0000;
-  display: inline-block;
-  font-size: 1.9980000000000002px;
-  position: relative;
-  text-indent: -99999em;
-  -webkit-transform: translate3D(0,0,0);
-  -ms-transform: translate3D(0,0,0);
-  transform: translate3D(0,0,0);
-  vertical-align: middle;
-  margin: 0;
-}
-
-.c0::before,
-.c0::after {
-  background-color: #fff;
-  content: '';
-  height: 21.978px;
-  position: absolute;
-}
-
-.c0::before {
-  -webkit-animation: rotate 1.5s infinite ease 1.2s;
-  animation: rotate 1.5s infinite ease 1.2s;
-  border-radius: 21.978px 0 0 21.978px;
-  left: -0.9990000000000001px;
-  top: -0.9990000000000001px;
-  -webkit-transform-origin: 10.589400000000001px 10.989px;
-  -ms-transform-origin: 10.589400000000001px 10.989px;
-  transform-origin: 10.589400000000001px 10.989px;
-  width: 10.3854375px;
-}
-
-.c0::after {
-  -webkit-animation: rotate 1.5s infinite ease;
-  animation: rotate 1.5s infinite ease;
-  border-radius: 0 21.978px 21.978px 0;
-  left: 10.3854375px;
-  top: -0.5994px;
-  -webkit-transform-origin: -0.1998px 10.989px;
-  -ms-transform-origin: -0.1998px 10.989px;
-  transform-origin: -0.1998px 10.989px;
-  width: 11.186735400000002px;
-}
-
-<div
-            class="c0"
-          />
-        </div>
-      </section>
     </section>
   </article>
   <aside

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -92,7 +92,7 @@ class AccommodationObjectComponent extends React.Component {
         <article className="col-7">
           <section>
             {this.hasBagResults() && (
-              <header>
+              <header data-testid="accommodationObjectBAGHeader">
                 <ArticleHeading marginCollapse>{intl.formatMessage(messages.bag_objects)}</ArticleHeading>
               </header>
             )}
@@ -112,7 +112,7 @@ class AccommodationObjectComponent extends React.Component {
 
           <section>
             {this.hasBrkResults() && (
-              <header>
+              <header data-testid="accommodationObjectBRKHeader">
                 <ArticleHeading>{intl.formatMessage(messages.brk_objects)}</ArticleHeading>
               </header>
             )}

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -70,7 +70,7 @@ class AccommodationObjectComponent extends React.Component {
   render() {
     const { onInput } = this;
     const { filledInBy, notitie } = this.state;
-    const { intl, status } = this.props;
+    const { intl, status, brkData } = this.props;
     const { formatMessage } = intl;
 
     return (
@@ -82,32 +82,34 @@ class AccommodationObjectComponent extends React.Component {
               <ArticleHeading marginCollapse>{intl.formatMessage(messages.bag_objects)}</ArticleHeading>
             </header>
 
-            <OpenbareRuimte />
-
             <Woonplaats />
 
             <Nummeraanduiding />
+
+            <OpenbareRuimte />
+
+            <Gebied />
 
             <Verblijfsobject />
 
             <Pand />
           </section>
 
-          <section>
-            <header>
-              <ArticleHeading>{intl.formatMessage(messages.brk_objects)}</ArticleHeading>
-            </header>
+          {!!brkData && (
+            <section>
+              <header>
+                <ArticleHeading>{intl.formatMessage(messages.brk_objects)}</ArticleHeading>
+              </header>
 
-            <KadastraalObject />
+              <KadastraalObject />
 
-            <KadastraalSubjectNP />
+              <KadastraalSubjectNP />
 
-            <KadastraalSubjectNNP />
+              <KadastraalSubjectNNP />
 
-            <Vestiging />
-
-            <Gebied />
-          </section>
+              <Vestiging />
+            </section>
+          )}
         </article>
 
         <Aside className="col-4">
@@ -175,6 +177,7 @@ AccommodationObjectComponent.defaultProps = {
 };
 
 AccommodationObjectComponent.propTypes = {
+  brkData: PropTypes.shape({}),
   status: PropTypes.string,
   intl: intlShape.isRequired,
   loadBAGData: PropTypes.func.isRequired,

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -23,6 +23,7 @@ import messages from 'containers/App/messages';
 import { LOAD_DATA_SUCCESS } from 'containers/App/constants';
 import SectionHeading from 'components/SectionHeading';
 import ArticleHeading from 'components/ArticleHeading';
+import { summaryPropType } from 'utils/propTypes';
 
 import { Textarea, Aside, Label, Wrapper } from './styled';
 
@@ -67,10 +68,22 @@ class AccommodationObjectComponent extends React.Component {
     }
   }
 
+  hasBagResults() {
+    const summaryKeys = Object.keys(this.props.summary);
+
+    return summaryKeys.some(key =>
+      ['accommodation_object_id', 'house_id', 'public_space_id', 'number_indication_id'].includes(key),
+    );
+  }
+
+  hasBrkResults() {
+    return Object.keys(this.props.summary).includes('cadastral_object_nr');
+  }
+
   render() {
     const { onInput } = this;
     const { filledInBy, notitie } = this.state;
-    const { intl, status, brkData } = this.props;
+    const { intl, status } = this.props;
     const { formatMessage } = intl;
 
     return (
@@ -78,9 +91,11 @@ class AccommodationObjectComponent extends React.Component {
         <Progress />
         <article className="col-7">
           <section>
-            <header>
-              <ArticleHeading marginCollapse>{intl.formatMessage(messages.bag_objects)}</ArticleHeading>
-            </header>
+            {this.hasBagResults() && (
+              <header>
+                <ArticleHeading marginCollapse>{intl.formatMessage(messages.bag_objects)}</ArticleHeading>
+              </header>
+            )}
 
             <Woonplaats />
 
@@ -95,21 +110,21 @@ class AccommodationObjectComponent extends React.Component {
             <Pand />
           </section>
 
-          {!!brkData && (
-            <section>
+          <section>
+            {this.hasBrkResults() && (
               <header>
                 <ArticleHeading>{intl.formatMessage(messages.brk_objects)}</ArticleHeading>
               </header>
+            )}
 
-              <KadastraalObject />
+            <KadastraalObject />
 
-              <KadastraalSubjectNP />
+            <KadastraalSubjectNP />
 
-              <KadastraalSubjectNNP />
+            <KadastraalSubjectNNP />
 
-              <Vestiging />
-            </section>
-          )}
+            <Vestiging />
+          </section>
         </article>
 
         <Aside className="col-4">
@@ -173,11 +188,12 @@ class AccommodationObjectComponent extends React.Component {
 }
 
 AccommodationObjectComponent.defaultProps = {
+  summary: {},
   status: undefined,
 };
 
 AccommodationObjectComponent.propTypes = {
-  brkData: PropTypes.shape({}),
+  summary: summaryPropType,
   status: PropTypes.string,
   intl: intlShape.isRequired,
   loadBAGData: PropTypes.func.isRequired,

--- a/app/components/Section/index.js
+++ b/app/components/Section/index.js
@@ -25,12 +25,20 @@ const printValue = meta => {
       return (
         <FormattedNumber
           value={formattedValue}
-          style="currency" // eslint-disable-line
+          // disabling linter, because it will trip over the use of the 'style' prop
+          // eslint-disable-next-line react/style-prop-object
+          style="currency"
           currency="EUR"
           currencyDisplay="symbol"
           minimumFractionDigits={0}
           maximumFractionDigits={0}
         />
+      );
+    case 'surface':
+      return (
+        <>
+          <FormattedNumber value={formattedValue} /> m<sup>2</sup>
+        </>
       );
     default:
       return formattedValue;

--- a/app/components/Summary/index.js
+++ b/app/components/Summary/index.js
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { intlShape } from 'react-intl';
 import styled from 'styled-components';
 
+import { summaryPropType } from 'utils/propTypes';
 import SectionHeading from 'components/SectionHeading';
 import messages from 'containers/App/messages';
 import LoadingIndicator from 'components/LoadingIndicator';
@@ -37,22 +37,8 @@ const Summary = ({ data, intl: { locale, formatMessage } }) => {
   );
 };
 
-const dataShape = {
-  label: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }),
-  value: PropTypes.string.isRequired,
-};
-
 Summary.propTypes = {
-  data: PropTypes.shape({
-    RSIN: PropTypes.shape(dataShape),
-    accommodation_object_id: PropTypes.shape(dataShape),
-    cadastral_object_nr: PropTypes.shape(dataShape),
-    chamber_of_commerce_nr: PropTypes.shape(dataShape),
-    house_id: PropTypes.shape(dataShape),
-    number_indication_id: PropTypes.shape(dataShape),
-  }),
+  data: summaryPropType,
   intl: intlShape.isRequired,
 };
 

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -5,6 +5,7 @@ import { createStructuredSelector } from 'reselect';
 
 import injectSaga from 'utils/injectSaga';
 import { makeSelectStatus } from 'containers/App/selectors';
+import { makeSelectKadastraalObjectData } from 'containers/KadastraalObject/selectors';
 import { loadBAGData } from 'containers/App/actions';
 import AccObjPageComponent from 'components/AccommodationObject';
 import saga from './saga';
@@ -12,6 +13,7 @@ import saga from './saga';
 const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
 
 const mapStateToProps = createStructuredSelector({
+  brkData: makeSelectKadastraalObjectData(),
   status: makeSelectStatus(),
 });
 

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -5,7 +5,7 @@ import { createStructuredSelector } from 'reselect';
 
 import injectSaga from 'utils/injectSaga';
 import { makeSelectStatus } from 'containers/App/selectors';
-import { makeSelectKadastraalObjectData } from 'containers/KadastraalObject/selectors';
+import { makeSelectSummary } from 'containers/Summary/selectors';
 import { loadBAGData } from 'containers/App/actions';
 import AccObjPageComponent from 'components/AccommodationObject';
 import saga from './saga';
@@ -13,7 +13,7 @@ import saga from './saga';
 const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
 
 const mapStateToProps = createStructuredSelector({
-  brkData: makeSelectKadastraalObjectData(),
+  summary: makeSelectSummary(),
   status: makeSelectStatus(),
 });
 

--- a/app/containers/Gebied/index.js
+++ b/app/containers/Gebied/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import Section from 'components/Section';
 import { OBJECTS, LOAD_DATA_FAILED } from 'containers/App/constants';
 import { makeSelectStatus } from 'containers/App/selectors';
@@ -23,14 +24,7 @@ GebiedContainer.defaultProps = {
 };
 
 GebiedContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/GlobalError/messages.js
+++ b/app/containers/GlobalError/messages.js
@@ -23,7 +23,7 @@ export default defineMessages({
   resource_not_found: {
     id: `${scope}.resource_not_found`,
   },
-  no_data_available: {
-    id: `${scope}.no_data_available`,
+  no_vbo_data_available: {
+    id: `${scope}.no_vbo_data_available`,
   },
 });

--- a/app/containers/KadastraalObject/index.js
+++ b/app/containers/KadastraalObject/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -24,17 +25,7 @@ export const KadastraalObjectContainer = ({ data, intl, status }) => {
 };
 
 KadastraalObjectContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string.isRequired,
-        formattedKey: PropTypes.string.isRequired,
-        formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-        key: PropTypes.string.isRequired,
-        value: PropTypes.any,
-      }),
-    ),
-  ),
+  data: PropTypes.oneOfType([dataPropType, PropTypes.arrayOf(dataPropType)]),
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/KadastraalObject/reducer.js
+++ b/app/containers/KadastraalObject/reducer.js
@@ -6,6 +6,7 @@ export const initialState = {
   data: undefined,
   adresseerbaarObjectId: null,
   error: false,
+  errorMessage: '',
 };
 
 /* eslint-disable default-case, no-param-reassign */
@@ -14,23 +15,32 @@ export default (state = initialState, action) =>
     switch (action.type) {
       case LOAD_DATA_PENDING:
         draft.data = undefined;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA:
         draft.adresseerbaarObjectId = action.payload.adresseerbaarObjectId;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA_SUCCESS:
         draft.data = action.payload;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA_FAILED:
         draft.data = null;
-        draft.error = action.payload;
+        draft.error = true;
+        draft.errorMessage = action.payload;
         break;
 
       case LOAD_DATA_NO_RESULTS:
         draft.data = null;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
     }
   });

--- a/app/containers/KadastraalObject/saga.js
+++ b/app/containers/KadastraalObject/saga.js
@@ -9,16 +9,22 @@ import { LOAD_DATA } from './constants';
 import { loadDataSuccess, loadDataFailed, loadDataNoResults } from './actions';
 
 const { API_ROOT } = configuration;
-const BRK_OBJECT_API = `${API_ROOT}brk/object-expand/?verblijfsobjecten__id=`;
+const BRK_OBJECT_API = `${API_ROOT}brk/object-expand/`;
+
+export const isKadastraalNummer = id => id.startsWith('NL.KAD');
 
 export function* fetchKadastraalObjectData(adresseerbaarObjectId) {
+  const endpoint = isKadastraalNummer(adresseerbaarObjectId)
+    ? `${BRK_OBJECT_API}${adresseerbaarObjectId}/`
+    : `${BRK_OBJECT_API}?verblijfsobjecten__id=${adresseerbaarObjectId}`;
+
   try {
-    const data = yield call(request, `${BRK_OBJECT_API}${adresseerbaarObjectId}`, getRequestOptions());
+    const data = yield call(request, endpoint, getRequestOptions());
 
     if (data) {
-      const { count } = data;
+      const { count, id } = data;
 
-      if (count && count > 0) {
+      if ((count && count > 0) || id) {
         yield put(loadDataSuccess(data));
       } else {
         yield put(loadDataNoResults());

--- a/app/containers/KadastraalObject/selectors.js
+++ b/app/containers/KadastraalObject/selectors.js
@@ -20,13 +20,19 @@ export const makeSelectKadastraalObjectData = () =>
 
       const { data: { results } = {} } = state;
 
-      if (!results || !isArray(results) || !results.length) {
-        return null;
-      }
-
       const keys = ['id', 'in_onderzoek', 'koopjaar', 'koopsom', 'objectnummer', 'aanduiding'];
 
-      return results.map(object => formatData({ data: object, keys, locale }));
+      if (results) {
+        return results.map(object => formatData({ data: object, keys, locale }));
+      }
+
+      const { data } = state;
+
+      if (data.id) {
+        return formatData({ data, keys });
+      }
+
+      return null;
     },
   );
 

--- a/app/containers/KadastraalSubjectNNP/index.js
+++ b/app/containers/KadastraalSubjectNNP/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,17 +29,7 @@ KadastraalSubjectNNPContainer.defaultProps = {
 };
 
 KadastraalSubjectNNPContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string.isRequired,
-        formattedKey: PropTypes.string.isRequired,
-        formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-        key: PropTypes.string.isRequired,
-        value: PropTypes.any,
-      }),
-    ),
-  ),
+  data: PropTypes.arrayOf(dataPropType),
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/KadastraalSubjectNP/index.js
+++ b/app/containers/KadastraalSubjectNP/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,17 +29,7 @@ KadastraalSubjectNPContainer.defaultProps = {
 };
 
 KadastraalSubjectNPContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string.isRequired,
-        formattedKey: PropTypes.string.isRequired,
-        formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-        key: PropTypes.string.isRequired,
-        value: PropTypes.any,
-      }),
-    ),
-  ),
+  data: PropTypes.arrayOf(dataPropType),
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/Nummeraanduiding/index.js
+++ b/app/containers/Nummeraanduiding/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -30,15 +31,7 @@ NummeraanduidingContainer.defaultProps = {
 };
 
 NummeraanduidingContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/Nummeraanduiding/reducer.js
+++ b/app/containers/Nummeraanduiding/reducer.js
@@ -4,8 +4,8 @@ import { LOAD_DATA, LOAD_DATA_SUCCESS, LOAD_DATA_FAILED, LOAD_DATA_NO_RESULTS } 
 
 // The initial state of the App
 export const initialState = {
-  loading: false,
   error: false,
+  errorMessage: '',
   data: undefined,
   nummeraanduidingId: null,
 };
@@ -16,23 +16,32 @@ export default (state = initialState, action) =>
     switch (action.type) {
       case LOAD_DATA_PENDING:
         draft.data = undefined;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA:
         draft.nummeraanduidingId = action.payload.nummeraanduidingId;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA_SUCCESS:
         draft.data = action.payload;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
 
       case LOAD_DATA_FAILED:
         draft.data = null;
-        draft.error = action.payload;
+        draft.error = true;
+        draft.errorMessage = action.payload;
         break;
 
       case LOAD_DATA_NO_RESULTS:
         draft.data = null;
+        draft.error = false;
+        draft.errorMessage = '';
         break;
     }
   });

--- a/app/containers/Nummeraanduiding/selectors.js
+++ b/app/containers/Nummeraanduiding/selectors.js
@@ -17,7 +17,7 @@ export const makeSelectNummeraanduidingData = () =>
       const { data } = state;
 
       if (!data) {
-        return data;
+        return null;
       }
 
       const keys = [
@@ -61,7 +61,7 @@ export const makeSelectWoonplaatsId = () =>
       const { data } = state;
 
       if (!data || !data.woonplaats || !data.woonplaats.landelijk_id) {
-        return undefined;
+        return null;
       }
 
       return data.woonplaats.landelijk_id;
@@ -79,7 +79,7 @@ export const makeSelectOpenbareRuimteId = () =>
       const { data } = state;
 
       if (!data) {
-        return undefined;
+        return null;
       }
 
       return data.openbare_ruimte.landelijk_id;
@@ -98,7 +98,7 @@ export const makeSelectGebiedData = () =>
       const { data } = state;
 
       if (!data) {
-        return undefined;
+        return null;
       }
 
       data.wijk = data.buurtcombinatie;

--- a/app/containers/OpenbareRuimte/index.js
+++ b/app/containers/OpenbareRuimte/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,15 +29,7 @@ OpenbareRuimteContainer.defaultProps = {
 };
 
 OpenbareRuimteContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/Pand/index.js
+++ b/app/containers/Pand/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,20 +29,7 @@ PandContainer.defaultProps = {
 };
 
 PandContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.oneOfType([
-        PropTypes.shape({
-          id: PropTypes.string.isRequired,
-        }),
-        PropTypes.string,
-      ]).isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/TOC/reducer.js
+++ b/app/containers/TOC/reducer.js
@@ -25,40 +25,40 @@ export default (state = { toc: [] }, action) =>
         break;
 
       case LOAD_PAND_DATA_SUCCESS:
-        draft.toc[4] = OBJECTS.PAND.NAME;
+        draft.toc[5] = OBJECTS.PAND.NAME;
         break;
 
       case LOAD_NUMMERAANDUIDING_DATA_SUCCESS:
-        draft.toc[2] = OBJECTS.NUMMERAANDUIDING.NAME;
-        draft.toc[9] = OBJECTS.GEBIED.NAME;
+        draft.toc[1] = OBJECTS.NUMMERAANDUIDING.NAME;
+        draft.toc[3] = OBJECTS.GEBIED.NAME;
         break;
 
       case LOAD_KADASTRAAL_OBJECT_DATA_SUCCESS:
-        draft.toc[5] = OBJECTS.KADASTRAAL_OBJECT.NAME;
+        draft.toc[6] = OBJECTS.KADASTRAAL_OBJECT.NAME;
         break;
 
       case LOAD_KADASTRAAL_SUBJECT_NP_DATA_SUCCESS:
-        draft.toc[6] = OBJECTS.KADASTRAAL_SUBJECT_NP.NAME;
+        draft.toc[7] = OBJECTS.KADASTRAAL_SUBJECT_NP.NAME;
         break;
 
       case LOAD_KADASTRAAL_SUBJECT_NNP_DATA_SUCCESS:
-        draft.toc[7] = OBJECTS.KADASTRAAL_SUBJECT_NNP.NAME;
+        draft.toc[8] = OBJECTS.KADASTRAAL_SUBJECT_NNP.NAME;
         break;
 
       case LOAD_VERBLIJFSOBJECT_DATA_SUCCESS:
-        draft.toc[3] = OBJECTS.VERBLIJFSOBJECT.NAME;
+        draft.toc[4] = OBJECTS.VERBLIJFSOBJECT.NAME;
         break;
 
       case LOAD_VESTIGING_DATA_SUCCESS:
-        draft.toc[8] = OBJECTS.VESTIGING.NAME;
+        draft.toc[9] = OBJECTS.VESTIGING.NAME;
         break;
 
       case LOAD_OPENBARE_RUIMTE_DATA_SUCCESS:
-        draft.toc[0] = OBJECTS.OPENBARE_RUIMTE.NAME;
+        draft.toc[2] = OBJECTS.OPENBARE_RUIMTE.NAME;
         break;
 
       case LOAD_WOONPLAATS_DATA_SUCCESS:
-        draft.toc[1] = OBJECTS.WOONPLAATS.NAME;
+        draft.toc[0] = OBJECTS.WOONPLAATS.NAME;
         break;
     }
   });

--- a/app/containers/Verblijfsobject/index.js
+++ b/app/containers/Verblijfsobject/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -27,15 +28,7 @@ VerblijfsObjectContainer.defaultProps = {
 };
 
 VerblijfsObjectContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/Vestiging/index.js
+++ b/app/containers/Vestiging/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,15 +29,7 @@ VestigingContainer.defaultProps = {
 };
 
 VestigingContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/containers/Woonplaats/index.js
+++ b/app/containers/Woonplaats/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
 
+import { dataPropType } from 'utils/propTypes';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import Section from 'components/Section';
@@ -28,15 +29,7 @@ WoonplaatsContainer.defaultProps = {
 };
 
 WoonplaatsContainer.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      formattedKey: PropTypes.string.isRequired,
-      formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      key: PropTypes.string.isRequired,
-      value: PropTypes.any,
-    }),
-  ),
+  data: dataPropType,
   intl: intlShape.isRequired,
   status: PropTypes.string,
 };

--- a/app/translations/nl.json
+++ b/app/translations/nl.json
@@ -51,5 +51,5 @@
   "registraties.service_unavailable": "Een van de databronnen is niet beschikbaar. Probeer het over een paar minuten nogmaals.",
   "registraties.filled_in_by": "Ingevuld door",
   "registraties.resource_not_found": "Een of meerdere databronnen zijn niet beschikbaar of retourneerden geen gegevens. Controleer de URL of probeer het over enkele minuten nogmaals.",
-  "registraties.no_data_available": "Er konden geen relevante gegevens gevonden worden"
+  "registraties.no_vbo_data_available": "Er konden geen verblijfsobject gegevens gevonden worden in de basisregistratie"
 }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -133,6 +133,23 @@ const formatKey = key =>
     .trim();
 
 /**
+ * Checks if a field with a number value is a value that should not be formatted as a number. This is the case
+ * for house numbers or years.
+ *
+ * @param   {String} key - field key to check
+ * @returns {Boolean}
+ */
+const shouldBeStringValue = key => ['huisnummer', 'oorspronkelijk_bouwjaar'].includes(key);
+
+/**
+ * Checks if a field's value should be tranformed by the field type
+ *
+ * @param   {String} type - a field's type
+ * @returns {Boolean}
+ */
+const isPlainValue = type => ['string', 'number', 'currency', 'surface'].includes(type);
+
+/**
  * Returns a formatted dataset
  *
  * Will filter invalid keys and values out of the set, format values and apply translations to key values. A custom
@@ -161,6 +178,12 @@ export const formatData = ({ data, keys, locale = 'default' }) => {
         readableKey = `${key.slice(0, 3).toUpperCase()}-${key.slice(3).replace('_', '')}`;
       }
 
+      if (key === 'oppervlakte') {
+        type = 'surface';
+      } else if (shouldBeStringValue(key)) {
+        type = 'string';
+      }
+
       try {
         if (type === 'boolean') {
           formattedValue = value ? localeMessages[messages.yes.id] : localeMessages[messages.no.id];
@@ -171,7 +194,7 @@ export const formatData = ({ data, keys, locale = 'default' }) => {
         } else if (value === null) {
           type = 'boolean';
           formattedValue = localeMessages[messages.unknown.id];
-        } else if (type === 'string' || type === 'number' || type === 'currency') {
+        } else if (isPlainValue(type)) {
           formattedValue = value;
         } else if (isCount(value)) {
           type = 'number';

--- a/app/utils/propTypes.js
+++ b/app/utils/propTypes.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+
+export const dataPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    formattedKey: PropTypes.oneOfType([
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+      }),
+      PropTypes.string,
+    ]).isRequired,
+    formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    key: PropTypes.string.isRequired,
+    value: PropTypes.any,
+  }),
+);
+
+const dataShape = {
+  label: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }),
+  value: PropTypes.string.isRequired,
+};
+
+export const summaryPropType = PropTypes.shape({
+  RSIN: PropTypes.shape(dataShape),
+  accommodation_object_id: PropTypes.shape(dataShape),
+  cadastral_object_nr: PropTypes.shape(dataShape),
+  chamber_of_commerce_nr: PropTypes.shape(dataShape),
+  house_id: PropTypes.shape(dataShape),
+  number_indication_id: PropTypes.shape(dataShape),
+});


### PR DESCRIPTION
This PR:
- changes the order of the sections in the `AccommodationObject` component
- Injects summary selector result into `AccommodationObject` component so that section headers can be rendered based on the incoming data
- Extracts prop types into separate utils export
- Unifies error statuses in reducers
- formats surface area as square meter notation
- resets global error message on data fetch
- adds extra check in `KadastraalObject` saga for brkId so that data can be retrieved with the correct parameters from the `brk` endpoint