### PR TITLE
(Chore) Nested value render

### DIFF
--- a/app/components/List/__tests__/__snapshots__/List.test.js.snap
+++ b/app/components/List/__tests__/__snapshots__/List.test.js.snap
@@ -1,30 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`List should match the snapshot 1`] = `
-.c1 {
-  padding: 0;
+.c0 {
   list-style: none;
   padding-bottom: 30px;
 }
 
-.c1:not(:first-child) {
+.c0,
+.c0 ul {
+  padding: 0;
+}
+
+.c0:not(:first-child) {
   border-bottom: 4px solid #767676;
 }
 
-.c1 li:last-of-type ul {
+.c0 li:last-of-type ul {
   padding-bottom: 0;
 }
 
-.c1 *:last-of-type > *:last-of-type ul:last-of-type {
+.c0 *:last-of-type > *:last-of-type ul:last-of-type {
   border: 0;
 }
 
-.c1 li {
+.c0 li {
   padding-left: 23px;
   position: relative;
 }
 
-.c1 li:before {
+.c0 li:before {
   content: '';
   position: absolute;
   left: 0;
@@ -34,16 +38,20 @@ exports[`List should match the snapshot 1`] = `
   background-color: #767676;
 }
 
-.c1 .c0 li {
+.c0 li.is-nested {
   padding-left: 0;
 }
 
-.c1 .c0 li:before {
+.c0 li.is-nested ul {
+  padding-bottom: 1em;
+}
+
+.c0 li.is-nested:before {
   content: none;
 }
 
 <ul
-  class="c0 c1"
+  class="c0"
 >
   <li>
     Item #1

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Ul = styled.ul`
-  padding: 0;
+  &,
+  ul {
+    padding: 0;
+  }
+
   list-style: none;
   padding-bottom: 30px;
 
@@ -34,7 +38,11 @@ const Ul = styled.ul`
     }
   }
 
-  & & li {
+  li.is-nested {
+    ul {
+      padding-bottom: 1em;
+    }
+
     padding-left: 0;
 
     &:before {

--- a/app/components/Section/index.js
+++ b/app/components/Section/index.js
@@ -59,7 +59,7 @@ export const SectionComponent = ({ name, href, data, intl }) => {
     }
 
     return (
-      <li key={listItem.key || Math.random()}>
+      <li key={listItem.key || Math.random()} className={isArray(listItem) ? 'is-nested' : null}>
         {isArray(listItem) ? (
           renderList(listItem)
         ) : (
@@ -75,7 +75,12 @@ export const SectionComponent = ({ name, href, data, intl }) => {
     <List>
       {listData.map(listItem => {
         if (isArray(listItem.formattedValue)) {
-          return listItem.formattedValue.map(value => renderListItem(value));
+          return (
+            <li key={listItem.key || Math.random()}>
+              {listItem.formattedKey}
+              {renderList(listItem.formattedValue)}
+            </li>
+          );
         }
 
         return renderListItem(listItem);

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -109,14 +109,6 @@ const isCount = value => isObject(value) && value.count;
 const isPostCode = value => /^\d{4}[A-Z]{2}$/i.test(value);
 
 /**
- * KVK field key detector
- *
- * @param {String} key
- * @returns {Boolean}
- */
-const keyIsKVK = key => /^kvk/i.test(key);
-
-/**
  * Currency detector
  *
  * @param {String} key
@@ -197,7 +189,7 @@ export const formatData = ({ data, keys, locale = 'default' }) => {
       let type = isCurrency(key, value) ? 'currency' : typeof value;
       let readableKey = formatKey(key);
 
-      if (keyIsKVK(key)) {
+      if (key.startsWith('kvk') || key.startsWith('sbi')) {
         readableKey = `${key.slice(0, 3).toUpperCase()}-${key.slice(3).replace('_', '')}`;
       }
 

--- a/app/utils/propTypes.js
+++ b/app/utils/propTypes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-export const dataPropType = PropTypes.arrayOf(
+const dataType = PropTypes.arrayOf(
   PropTypes.shape({
     type: PropTypes.string.isRequired,
     formattedKey: PropTypes.oneOfType([
@@ -9,11 +9,14 @@ export const dataPropType = PropTypes.arrayOf(
       }),
       PropTypes.string,
     ]).isRequired,
-    formattedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     key: PropTypes.string.isRequired,
     value: PropTypes.any,
   }),
 );
+
+dataType.formattedValue = PropTypes.oneOfType([PropTypes.string, PropTypes.number, dataType]).isRequired;
+
+export const dataPropType = PropTypes.oneOfType([dataType, PropTypes.arrayOf(dataType)]);
 
 const dataShape = {
   label: PropTypes.shape({


### PR DESCRIPTION
This PR contains changes that make sure that nested lists in page sections render properly by:
- updating the `data` prop type validator,
- separately renderering list items with their corresponding formatted key
- displaying bullets for nested list items