### PR TITLE
(Fix) Vestigingen by VBO id

### DIFF
--- a/app/components/List/__tests__/__snapshots__/List.test.js.snap
+++ b/app/components/List/__tests__/__snapshots__/List.test.js.snap
@@ -2,21 +2,36 @@
 
 exports[`List should match the snapshot 1`] = `
 .c0 {
-  padding: 0;
+  padding-left: 0;
   list-style: none;
+}
+
+.c0.depth-1 {
+  padding: 0 0 30px;
+}
+
+.c0.depth-1 ul {
+  padding: 0;
+}
+
+.c0.depth-2 > li {
+  padding-left: 0;
+}
+
+.c0.depth-2 > li > ul {
   padding-bottom: 30px;
+}
+
+.c0.depth-2 > li > ul > li.has-list {
+  padding-left: 0 !important;
+}
+
+.c0.depth-2 > li:before {
+  content: none;
 }
 
 .c0:not(:first-child) {
   border-bottom: 4px solid #767676;
-}
-
-.c0 li:last-of-type ul {
-  padding-bottom: 0;
-}
-
-.c0 *:last-of-type > *:last-of-type ul:last-of-type {
-  border: 0;
 }
 
 .c0 li {
@@ -32,23 +47,6 @@ exports[`List should match the snapshot 1`] = `
   height: 8px;
   margin-top: 7px;
   background-color: #767676;
-}
-
-.c0.is-nested {
-  padding-bottom: 0;
-}
-
-.c0.is-nested ul:not(:last-of-type),
-.c0.is-nested:not(:last-of-type) {
-  padding-bottom: 1em;
-}
-
-.c0.is-nested > li {
-  padding-left: 0;
-}
-
-.c0.is-nested > li:before {
-  content: none;
 }
 
 <ul

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -3,20 +3,37 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Ul = styled.ul`
-  padding: 0;
+  padding-left: 0;
+
+  &.depth-1 {
+    padding: 0 0 30px;
+
+    ul {
+      padding: 0;
+    }
+  }
   list-style: none;
-  padding-bottom: 30px;
+
+  &.depth-2 {
+    & > li {
+      padding-left: 0;
+
+      & > ul {
+        padding-bottom: 30px;
+
+        & > li.has-list {
+          padding-left: 0 !important;
+        }
+      }
+
+      & :before {
+        content: none;
+      }
+    }
+  }
 
   &:not(:first-child) {
     border-bottom: 4px solid #767676;
-  }
-
-  & li:last-of-type ul {
-    padding-bottom: 0;
-  }
-
-  *:last-of-type > *:last-of-type ul:last-of-type {
-    border: 0;
   }
 
   li {
@@ -31,23 +48,6 @@ const Ul = styled.ul`
       height: 8px;
       margin-top: 7px;
       background-color: #767676;
-    }
-  }
-
-  &.is-nested {
-    padding-bottom: 0;
-
-    ul:not(:last-of-type),
-    &:not(:last-of-type) {
-      padding-bottom: 1em;
-    }
-
-    & > li {
-      padding-left: 0;
-
-      &:before {
-        content: none;
-      }
     }
   }
 `;

--- a/app/components/Section/__tests__/Section.test.js
+++ b/app/components/Section/__tests__/Section.test.js
@@ -79,7 +79,7 @@ describe('Section', () => {
       </Provider>,
     );
 
-    expect(isArray).toHaveBeenCalledTimes(4); // will call isArrayOfArrays
+    expect(isArray).toHaveBeenCalledTimes(7); // will call isArrayOfArrays
     expect(isArray).toHaveBeenCalledWith(data[0]);
     expect(isArray).toHaveBeenLastCalledWith(data[1]);
     expect(document.getElementsByTagName('li')).toHaveLength(2);
@@ -96,7 +96,7 @@ describe('Section', () => {
       </Provider>,
     );
 
-    expect(isArray).toHaveBeenCalledTimes(3);
+    expect(isArray).toHaveBeenCalledTimes(5);
     expect(isArray).toHaveBeenCalledWith(data2[0]);
     expect(document.getElementsByTagName('li')).toHaveLength(1);
 
@@ -112,7 +112,7 @@ describe('Section', () => {
       </Provider>,
     );
 
-    expect(isArray).toHaveBeenCalledTimes(4);
+    expect(isArray).toHaveBeenCalledTimes(7);
     expect(document.getElementsByTagName('ul')).toHaveLength(2);
   });
 

--- a/app/components/Section/index.js
+++ b/app/components/Section/index.js
@@ -8,13 +8,31 @@ import List from 'components/List';
 import SectionHeading from 'components/SectionHeading';
 import LoadingIndicator from 'components/LoadingIndicator';
 import messages from 'containers/App/messages';
-import { isArray, isArrayOfArrays, isObject } from 'utils';
+import { isArray, isObject } from 'utils';
 
 import { Key, StelselpediaLink } from 'components/AccommodationObject/styled';
 
 const SectionWrapper = styled.section`
   position: relative;
 `;
+
+const max = (array, count = 0) => (isArray(array) ? max(maxDepth(array), count + 1) : count);
+
+const maxDepth = array => {
+  let maxVal = Number.MIN_VALUE;
+  let item;
+
+  array.forEach(val => {
+    const depth = max(val);
+
+    if (depth > maxVal) {
+      maxVal = depth;
+      item = val;
+    }
+  });
+
+  return item;
+};
 
 const printValue = meta => {
   const { type, formattedValue } = meta;
@@ -59,7 +77,7 @@ export const SectionComponent = ({ name, href, data, intl }) => {
     }
 
     return (
-      <li key={listItem.key || Math.random()}>
+      <li key={listItem.key || Math.random()} className={isArray(listItem) ? 'has-list' : null}>
         {isArray(listItem) ? (
           renderList(listItem)
         ) : (
@@ -71,16 +89,11 @@ export const SectionComponent = ({ name, href, data, intl }) => {
     );
   };
 
-  const renderList = listData => (
-    <List className={isArrayOfArrays(listData) ? 'is-nested' : null}>
+  const renderList = (listData, depth) => (
+    <List className={depth ? `depth-${depth}` : null}>
       {listData.map(listItem => {
         if (isArray(listItem.formattedValue)) {
-          return (
-            <li key={listItem.key || Math.random()}>
-              {listItem.formattedKey}
-              {renderList(listItem.formattedValue)}
-            </li>
-          );
+          return listItem.formattedValue.map(fValue => renderListItem(fValue));
         }
 
         return renderListItem(listItem);
@@ -109,7 +122,7 @@ export const SectionComponent = ({ name, href, data, intl }) => {
       {name && data !== null && <Title />}
 
       {data === undefined && <LoadingIndicator />}
-      {data && renderList(sectionData)}
+      {data && renderList(sectionData, max(sectionData))}
     </SectionWrapper>
   );
 };

--- a/app/containers/AccommodationObjectPage/saga.js
+++ b/app/containers/AccommodationObjectPage/saga.js
@@ -50,7 +50,7 @@ export function* fetchData(action) {
     let landelijkVboId;
 
     if (brkId) {
-      yield put(maxProgressCount(12));
+      yield put(maxProgressCount(11));
 
       // fetch vboId from VERBLIJFSOBJECT_API with brkId param
       landelijkVboId = yield* fetchVerblijfsobjectId(brkId);

--- a/app/containers/Verblijfsobject/selectors.js
+++ b/app/containers/Verblijfsobject/selectors.js
@@ -40,6 +40,24 @@ export const makeSelectVerblijfsobjectData = () =>
     },
   );
 
+export const makeSelectVerblijfsobjectId = () =>
+  createSelector(
+    selectVerblijfsobject,
+    state => {
+      if (!state) {
+        return undefined;
+      }
+
+      const { data } = state;
+
+      if (!data) {
+        return data;
+      }
+
+      return data.verblijfsobjectidentificatie;
+    },
+  );
+
 export const makeSelectVBONummeraanduidingId = () =>
   createSelector(
     selectVerblijfsobject,

--- a/app/containers/Vestiging/saga.js
+++ b/app/containers/Vestiging/saga.js
@@ -3,7 +3,7 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import request from 'utils/request';
 import { getRequestOptions } from 'shared/services/auth/auth';
 import configuration from 'shared/services/configuration/configuration';
-import { makeSelectFromObjectAppartment } from 'containers/KadastraalObject/selectors';
+import { makeSelectVerblijfsobjectId } from 'containers/Verblijfsobject/selectors';
 import { incrementProgress } from 'containers/App/actions';
 
 import { LOAD_DATA, LOAD_IDS } from './constants';
@@ -20,23 +20,19 @@ const { API_ROOT } = configuration;
 const VESTIGING_API = `${API_ROOT}handelsregister/vestiging/`;
 
 export function* fetchVestigingIdData() {
-  const brkObjectIds = yield select(makeSelectFromObjectAppartment('id'));
+  const vboId = yield select(makeSelectVerblijfsobjectId());
 
   try {
-    if (brkObjectIds && brkObjectIds.length) {
+    if (vboId) {
       // getting data to extract vestiging id from
-      const data = yield all([
-        ...brkObjectIds.map(brkObjectId =>
-          call(request, `${VESTIGING_API}?kadastraal_object=${brkObjectId}`, getRequestOptions()),
-        ),
-      ]);
+      const data = yield call(request, `${VESTIGING_API}?verblijfsobject=${vboId}`, getRequestOptions());
 
-      if (!data.length || data[0].count === 0) {
+      if (!data.count || !data.results.length) {
         yield put(loadIdsNoResults());
       } else {
         yield put(loadIdsSuccess());
 
-        yield all([...data.map(({ results }) => call(fetchVestigingData, results))]);
+        yield call(fetchVestigingData, data.results);
       }
     } else {
       yield put(loadIdsNoResults());


### PR DESCRIPTION
This PR:
- changes the way vestiging data is retrieved; instead of querying by BRK id, vestiging data is retrieved by VBO id
- alters the way lists and nested lists in `Section` components are rendered