### PR TITLE
(Fix) Nested list styling

### DIFF
--- a/app/components/List/__tests__/__snapshots__/List.test.js.snap
+++ b/app/components/List/__tests__/__snapshots__/List.test.js.snap
@@ -22,11 +22,15 @@ exports[`List should match the snapshot 1`] = `
   padding-bottom: 30px;
 }
 
-.c0.depth-2 > li > ul > li.has-list {
+.c0.depth-2 > li:before {
+  content: none;
+}
+
+.c0 > li.has-list {
   padding-left: 0 !important;
 }
 
-.c0.depth-2 > li:before {
+.c0 > li.has-list:before {
   content: none;
 }
 

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -20,15 +20,19 @@ const Ul = styled.ul`
 
       & > ul {
         padding-bottom: 30px;
-
-        & > li.has-list {
-          padding-left: 0 !important;
-        }
       }
 
-      & :before {
+      &:before {
         content: none;
       }
+    }
+  }
+
+  & > li.has-list {
+    padding-left: 0 !important;
+
+    &:before {
+      content: none;
     }
   }
 


### PR DESCRIPTION
Corrects a typo and moves a style rule out of another rule so that nested list items won't show content in their `before` pseudo element.