### PR TITLE
(Fix) Anchor line-height

### DIFF
--- a/app/components/List/__tests__/__snapshots__/List.test.js.snap
+++ b/app/components/List/__tests__/__snapshots__/List.test.js.snap
@@ -53,6 +53,10 @@ exports[`List should match the snapshot 1`] = `
   background-color: #767676;
 }
 
+.c0 li a {
+  line-height: normal;
+}
+
 <ul
   class="c0"
 >

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -53,6 +53,10 @@ const Ul = styled.ul`
       margin-top: 7px;
       background-color: #767676;
     }
+
+    a {
+      line-height: normal;
+    }
   }
 `;
 


### PR DESCRIPTION
Fixes an issue where, in IE and older versions of FF, the outline on anchor focus would leave a gap between the anchor background colour and the outline.