### PR TITLE
BW-28 accommodation object page container tests

### DIFF
--- a/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
+++ b/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
@@ -85,9 +85,9 @@ exports[`AccommodationObject should render without problems 1`] = `
 }
 
 .c2::before {
-  -webkit-transform: rotate(NaNdeg);
-  -ms-transform: rotate(NaNdeg);
-  transform: rotate(NaNdeg);
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
 }
 
 .c2::after {
@@ -299,7 +299,7 @@ exports[`AccommodationObject should render without problems 1`] = `
       class="c3"
       data-testid="progress-label"
     >
-      NaN %
+      0 %
     </div>
   </div>
   <article
@@ -499,9 +499,9 @@ exports[`AccommodationObject should render without problems 2`] = `
 }
 
 .c0::before {
-  -webkit-transform: rotate(NaNdeg);
-  -ms-transform: rotate(NaNdeg);
-  transform: rotate(NaNdeg);
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
 }
 
 .c0::after {
@@ -522,7 +522,7 @@ exports[`AccommodationObject should render without problems 2`] = `
       class="Progress__Label-yfxggj-2 fWvHLa"
       data-testid="progress-label"
     >
-      NaN %
+      0 %
     </div>
   </div>
   <article

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -192,8 +192,8 @@ AccommodationObjectComponent.defaultProps = {
 };
 
 AccommodationObjectComponent.propTypes = {
-  summary: PropTypes.func,
-  status: PropTypes.func,
+  summary: PropTypes.shape({}),
+  status: PropTypes.string,
   intl: intlShape.isRequired,
   loadBAGData: PropTypes.func.isRequired,
   match: PropTypes.shape({

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -23,7 +23,6 @@ import messages from 'containers/App/messages';
 import { LOAD_DATA_SUCCESS } from 'containers/App/constants';
 import SectionHeading from 'components/SectionHeading';
 import ArticleHeading from 'components/ArticleHeading';
-import { summaryPropType } from 'utils/propTypes';
 
 import { Textarea, Aside, Label, Wrapper } from './styled';
 
@@ -188,13 +187,13 @@ class AccommodationObjectComponent extends React.Component {
 }
 
 AccommodationObjectComponent.defaultProps = {
-  summary: {},
+  summary: undefined,
   status: undefined,
 };
 
 AccommodationObjectComponent.propTypes = {
-  summary: summaryPropType,
-  status: PropTypes.string,
+  summary: PropTypes.func,
+  status: PropTypes.func,
   intl: intlShape.isRequired,
   loadBAGData: PropTypes.func.isRequired,
   match: PropTypes.shape({

--- a/app/components/AccommodationObject/index.js
+++ b/app/components/AccommodationObject/index.js
@@ -187,7 +187,7 @@ class AccommodationObjectComponent extends React.Component {
 }
 
 AccommodationObjectComponent.defaultProps = {
-  summary: undefined,
+  summary: {},
   status: undefined,
 };
 

--- a/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
@@ -1,39 +1,26 @@
 import React from 'react';
-import * as effects from 'redux-saga/effects';
+// import * as effects from 'redux-saga/effects';
 // import { render, cleanup, fireEvent } from 'react-testing-library';
 import { mount } from 'enzyme';
 import { IntlProvider } from 'react-intl';
 import history from 'utils/history';
 import { Provider } from 'react-redux';
 
-import * as actions from 'containers/App/actions';
+// import * as actions from 'containers/App/actions';
 
 import messages from '../../../translations/nl.json';
 import AccommodationObjectPageContainer from '..';
 
 import configureStore from '../../../configureStore';
-const store = configureStore({}, history);
-
-// jest.mock('redux');
-jest.mock('redux-saga/effects', () => {
-  const actual = jest.requireActual('redux-saga/effects');
-
-  return {
-    __esModule: true,
-    ...actual,
-    put: jest.fn(),
-  };
-});
+const store = configureStore({ global: { status: undefined } }, history);
 
 describe('AccommodationObjectPageContainer', () => {
   it('should export a composed component', () => {
-    // expect(AccommodationObjectPageContainer).toBeInstanceOf()
+    expect(AccommodationObjectPageContainer).toBeInstanceOf('Foo');
   });
 
-  it('should inject translations', () => {});
-
   it('should inject saga', () => {
-    const putSpy = jest.spyOn(effects, 'put');
+    // const putSpy = jest.spyOn(effects, 'put');
     const vboId = 'fooBarBaz';
 
     const tree = mount(
@@ -44,10 +31,6 @@ describe('AccommodationObjectPageContainer', () => {
       </Provider>,
     );
 
-    tree.debug();
-
-    actions.loadBAGData({ vboId });
-
-    expect(putSpy).toHaveBeenCalledWith('watchAccommodationObjectPageSaga');
+    console.log(tree.find(AccommodationObjectPageContainer).props());
   });
 });

--- a/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
@@ -1,7 +1,53 @@
-// import AccommodationObjectPageContainer from '..';
+import React from 'react';
+import * as effects from 'redux-saga/effects';
+// import { render, cleanup, fireEvent } from 'react-testing-library';
+import { mount } from 'enzyme';
+import { IntlProvider } from 'react-intl';
+import history from 'utils/history';
+import { Provider } from 'react-redux';
 
-describe('AccommodationObjectPage', () => {
+import * as actions from 'containers/App/actions';
+
+import messages from '../../../translations/nl.json';
+import AccommodationObjectPageContainer from '..';
+
+import configureStore from '../../../configureStore';
+const store = configureStore({}, history);
+
+// jest.mock('redux');
+jest.mock('redux-saga/effects', () => {
+  const actual = jest.requireActual('redux-saga/effects');
+
+  return {
+    __esModule: true,
+    ...actual,
+    put: jest.fn(),
+  };
+});
+
+describe('AccommodationObjectPageContainer', () => {
   it('should export a composed component', () => {
     // expect(AccommodationObjectPageContainer).toBeInstanceOf()
+  });
+
+  it('should inject translations', () => {});
+
+  it('should inject saga', () => {
+    const putSpy = jest.spyOn(effects, 'put');
+    const vboId = 'fooBarBaz';
+
+    const tree = mount(
+      <Provider store={store}>
+        <IntlProvider locale="nl" messages={messages}>
+          <AccommodationObjectPageContainer match={{ params: { vboId } }} />
+        </IntlProvider>
+      </Provider>,
+    );
+
+    tree.debug();
+
+    actions.loadBAGData({ vboId });
+
+    expect(putSpy).toHaveBeenCalledWith('watchAccommodationObjectPageSaga');
   });
 });

--- a/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
@@ -13,7 +13,7 @@ import configureStore from '../../../configureStore';
 const store = configureStore({}, history);
 
 describe('AccommodationObjectPageContainer', () => {
-  it.only('should have props from structured selector', () => {
+  it('should have props from structured selector', () => {
     const vboId = 'fooBarBaz';
     const tree = mount(
       <Provider store={store}>
@@ -24,23 +24,9 @@ describe('AccommodationObjectPageContainer', () => {
     );
 
     const props = tree.find(AccommodationObjectPageComponent).props();
+
     expect(props.summary).toEqual({});
     expect(props.loadBAGData).not.toBeUndefined();
     expect(props.loadBAGData({ vboId })).toEqual(loadBAGData({ vboId }));
-  });
-
-  it('should inject saga', () => {
-    // const putSpy = jest.spyOn(effects, 'put');
-    const vboId = 'fooBarBaz';
-
-    const tree = mount(
-      <Provider store={store}>
-        <IntlProvider locale="nl" messages={messages}>
-          <AccommodationObjectPageContainer match={{ params: { vboId } }} />
-        </IntlProvider>
-      </Provider>,
-    );
-
-    console.log(tree.find(AccommodationObjectPageContainer).props());
   });
 });

--- a/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
@@ -1,22 +1,32 @@
 import React from 'react';
-// import * as effects from 'redux-saga/effects';
-// import { render, cleanup, fireEvent } from 'react-testing-library';
 import { mount } from 'enzyme';
 import { IntlProvider } from 'react-intl';
 import history from 'utils/history';
 import { Provider } from 'react-redux';
 
-// import * as actions from 'containers/App/actions';
+import { loadBAGData } from 'containers/App/actions';
 
 import messages from '../../../translations/nl.json';
-import AccommodationObjectPageContainer from '..';
-
+import AccommodationObjectPageContainer, { AccommodationObjectPageComponent } from '..';
 import configureStore from '../../../configureStore';
-const store = configureStore({ global: { status: undefined } }, history);
+
+const store = configureStore({}, history);
 
 describe('AccommodationObjectPageContainer', () => {
-  it('should export a composed component', () => {
-    expect(AccommodationObjectPageContainer).toBeInstanceOf('Foo');
+  it.only('should have props from structured selector', () => {
+    const vboId = 'fooBarBaz';
+    const tree = mount(
+      <Provider store={store}>
+        <IntlProvider locale="nl" messages={messages}>
+          <AccommodationObjectPageContainer match={{ params: { vboId } }} />
+        </IntlProvider>
+      </Provider>,
+    );
+
+    const props = tree.find(AccommodationObjectPageComponent).props();
+    expect(props.summary).toEqual({});
+    expect(props.loadBAGData).not.toBeUndefined();
+    expect(props.loadBAGData({ vboId })).toEqual(loadBAGData({ vboId }));
   });
 
   it('should inject saga', () => {

--- a/app/containers/AccommodationObjectPage/__tests__/saga.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/saga.test.js
@@ -27,7 +27,7 @@ import { makeSelectLIGNummeraanduidingId } from 'containers/Ligplaats/selectors'
 
 import watchAccommodationObjectPageSaga, { fetchData } from '../saga';
 
-describe('AccommodationObjectPage/saga', () => {
+describe('containers/AccommodationObjectPage/saga', () => {
   const action = { type: appConstants.LOAD_BAG_DATA };
 
   it('should watch "LOAD_BAG_DATA" and call fetchData', () => {

--- a/app/containers/AccommodationObjectPage/__tests__/saga.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/saga.test.js
@@ -1,0 +1,193 @@
+import * as constants from 'containers/App/constants';
+import * as verblijfsobjectSelectors from 'containers/Verblijfsobject/selectors';
+
+import { fetchData } from '../saga';
+
+describe('saga', () => {
+  describe('watchAccommodationObjectPageSaga', () => {
+    it('should spawn the App saga', () => {
+      expect(false).toBeTruthy();
+    });
+    it('should fetch data on LOAD_BAG_DATA', () => {
+      expect(false).toBeTruthy();
+    });
+  });
+
+  describe.only('fetchData', () => {
+    const vboId = '0363010001008585';
+    // const brkId = 'NL.KAD.OnroerendeZaak.11520480510035';
+    // const ligId = '0363020001027057';
+    const generator = fetchData({ payload: { vboId } });
+
+    it('should reset progress', () => {
+      const val = generator.next().value;
+
+      expect(val.type).toBe('PUT');
+      expect(val.payload.action.type).toBe(constants.RESET_PROGRESS);
+    });
+
+    it('should set the global status to pending', () => {
+      const val = generator.next().value;
+
+      expect(val.type).toBe('PUT');
+      expect(val.payload.action.type).toBe(constants.LOAD_DATA_PENDING);
+    });
+
+    it('should reset the global error message', () => {
+      const val = generator.next().value;
+
+      expect(val.type).toBe('PUT');
+      expect(val.payload.action.type).toBe(constants.RESET_GLOBAL_ERROR);
+    });
+
+    describe('VBO', () => {
+      it('should set max progress count', () => {
+        const {
+          type,
+          payload: { action },
+        } = generator.next().value;
+
+        expect(type).toBe('PUT');
+        expect(action.type).toBe(constants.MAX_PROGRESS_COUNT);
+        expect(action.payload).toBe(10);
+      });
+
+      it('should call fetchKadastraalObjectData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchKadastraalObjectData');
+        expect(args).toStrictEqual([vboId]);
+      });
+
+      it('should call fetchVerblijfsobjectData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchVerblijfsobjectData');
+        expect(args).toStrictEqual([vboId]);
+      });
+
+      it('should call fetchKadastraalSubjectNNPData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchKadastraalSubjectNNPData');
+        expect(args).toStrictEqual([]);
+      });
+
+      it('should call fetchKadastraalSubjectNPData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchKadastraalSubjectNPData');
+        expect(args).toStrictEqual([]);
+      });
+
+      it('should call fetchVestigingIdData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchVestigingIdData');
+        expect(args).toStrictEqual([]);
+      });
+
+      it('should call fetchMaatschappelijkeActiviteitData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchMaatschappelijkeActiviteitData');
+        expect(args).toStrictEqual([]);
+      });
+
+      it('should call fetchPandlistData generator', () => {
+        const {
+          type,
+          payload: { fn, args },
+        } = generator.next().value;
+
+        expect(type).toBe('CALL');
+        expect(fn.constructor.name).toBe('GeneratorFunction');
+        expect(fn.name).toBe('fetchPandlistData');
+        expect(args).toStrictEqual([vboId]);
+      });
+
+      it('should select nummeraanduiding id', () => {
+        const makeSelectVBONummeraanduidingIdSpy = jest.spyOn(
+          verblijfsobjectSelectors,
+          'makeSelectVBONummeraanduidingId',
+        );
+        const { type } = generator.next().value;
+
+        expect(type).toBe('SELECT');
+        expect(makeSelectVBONummeraanduidingIdSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe.skip('BRK', () => {
+      it('should set max progress count', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should fetch verblijfsobjectId', () => {
+        expect(false).toBeTruthy();
+      });
+    });
+
+    describe.skip('LIG', () => {
+      it('should set max progress count', () => {
+        expect(false).toBeTruthy();
+      });
+    });
+
+    describe.skip('Exceptions', () => {
+      it('should catch a "failed to fetch" error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a "session_expired" error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a "unauthenticated" error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a 404 error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a 500 error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a 503 error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should catch a unknown error', () => {
+        expect(false).toBeTruthy();
+      });
+      it('should set the global status to failed', () => {
+        expect(false).toBeTruthy();
+      });
+    });
+  });
+});

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -10,7 +10,7 @@ import { loadBAGData } from 'containers/App/actions';
 import AccObjPageComponent from 'components/AccommodationObject';
 import saga from './saga';
 
-const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
+export const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
 
 const mapStateToProps = createStructuredSelector({
   summary: makeSelectSummary(),
@@ -30,8 +30,9 @@ const withConnect = connect(
   mapDispatchToProps,
 );
 
+const withInjectSaga = injectSaga({ key: 'accObjPage', saga });
+
 export default compose(
-  injectSaga({ key: 'accObjPage', saga }),
+  withInjectSaga,
   withConnect,
-  injectIntl,
 )(AccommodationObjectPageComponent);

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -10,7 +10,7 @@ import { loadBAGData } from 'containers/App/actions';
 import AccObjPageComponent from 'components/AccommodationObject';
 import saga from './saga';
 
-const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
+export const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
 
 const mapStateToProps = createStructuredSelector({
   summary: makeSelectSummary,
@@ -33,6 +33,6 @@ const withConnect = connect(
 const withInjectSaga = injectSaga({ key: 'accObjPage', saga });
 
 export default compose(
-  withInjectSaga,
   withConnect,
+  withInjectSaga,
 )(AccommodationObjectPageComponent);

--- a/app/containers/AccommodationObjectPage/index.js
+++ b/app/containers/AccommodationObjectPage/index.js
@@ -10,11 +10,11 @@ import { loadBAGData } from 'containers/App/actions';
 import AccObjPageComponent from 'components/AccommodationObject';
 import saga from './saga';
 
-export const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
+const AccommodationObjectPageComponent = injectIntl(AccObjPageComponent);
 
 const mapStateToProps = createStructuredSelector({
-  summary: makeSelectSummary(),
-  status: makeSelectStatus(),
+  summary: makeSelectSummary,
+  status: makeSelectStatus,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/app/containers/AccommodationObjectPage/saga.js
+++ b/app/containers/AccommodationObjectPage/saga.js
@@ -53,9 +53,10 @@ export function* fetchData(action) {
       yield put(maxProgressCount(11));
 
       // fetch vboId from VERBLIJFSOBJECT_API with brkId param
-      landelijkVboId = yield* fetchVerblijfsobjectId(brkId);
+      landelijkVboId = yield call(fetchVerblijfsobjectId, brkId);
     } else {
-      yield put(maxProgressCount(10));
+      const count = ligId ? 4 : 10;
+      yield put(maxProgressCount(count));
     }
 
     const vboIdentifier = vboId || landelijkVboId;
@@ -69,17 +70,15 @@ export function* fetchData(action) {
       yield call(fetchMaatschappelijkeActiviteitData);
       yield call(fetchPandlistData, vboIdentifier);
 
-      nummeraanduidingId = yield select(makeSelectVBONummeraanduidingId());
+      nummeraanduidingId = yield select(makeSelectVBONummeraanduidingId);
     } else if (ligId) {
-      yield put(maxProgressCount(4));
-
       yield call(fetchLigplaatsData, ligId);
 
       yield put(loadKadastraalObjectDataNoResults());
       yield put(loadKadastraalSubjectNPDataNoResults());
       yield put(loadKadastraalSubjectNNPDataNoResults());
 
-      nummeraanduidingId = yield select(makeSelectLIGNummeraanduidingId());
+      nummeraanduidingId = yield select(makeSelectLIGNummeraanduidingId);
     } else {
       // no verblijfsobject or ligplaats data could be retrieved with the identifiers that we have
       // the only thing left is to try to get BRK object and/or subject data
@@ -99,7 +98,7 @@ export function* fetchData(action) {
       yield call(fetchNummeraanduidingData, nummeraanduidingId);
       yield call(fetchWoonplaatsData);
 
-      const oprId = yield select(makeSelectOpenbareRuimteId());
+      const oprId = yield select(makeSelectOpenbareRuimteId);
       yield call(fetchOpenbareRuimteData, oprId);
 
       yield put(statusSuccess());
@@ -111,7 +110,7 @@ export function* fetchData(action) {
       yield put(statusUnableToFetch());
     } else if (error.response && error.response.status === 401) {
       // unauthorized
-      const isAuthenticated = yield select(makeSelectIsAuthenticated());
+      const isAuthenticated = yield select(makeSelectIsAuthenticated);
 
       if (isAuthenticated) {
         yield put(showGlobalError('session_expired'));

--- a/app/containers/App/__tests__/selectors.test.js
+++ b/app/containers/App/__tests__/selectors.test.js
@@ -7,7 +7,7 @@ import {
   makeSelectLocation,
 } from '../selectors';
 
-describe('selectGlobal', () => {
+describe('selectors', () => {
   it('should select the global state', () => {
     const globalState = {};
     const mockedState = {
@@ -15,10 +15,7 @@ describe('selectGlobal', () => {
     };
     expect(selectGlobal(mockedState)).toEqual(globalState);
   });
-});
 
-describe('makeSelectUserName', () => {
-  const userNameSelector = makeSelectUserName();
   it('should select the current user', () => {
     const username = 'loggedInUser';
     const mockedState = {
@@ -26,12 +23,9 @@ describe('makeSelectUserName', () => {
         userName: username,
       },
     };
-    expect(userNameSelector(mockedState)).toEqual(username);
+    expect(makeSelectUserName(mockedState)).toEqual(username);
   });
-});
 
-describe('makeSelectAccessToken', () => {
-  const selector = makeSelectAccessToken();
   it('should select the token', () => {
     const accessToken = 'thisistheaccesstoken';
     const mockedState = {
@@ -39,12 +33,9 @@ describe('makeSelectAccessToken', () => {
         accessToken,
       },
     };
-    expect(selector(mockedState)).toEqual(accessToken);
+    expect(makeSelectAccessToken(mockedState)).toEqual(accessToken);
   });
-});
 
-describe('makeSelectLoading', () => {
-  const loadingSelector = makeSelectLoading();
   it('should select the loading', () => {
     const loading = false;
     const mockedState = {
@@ -52,12 +43,9 @@ describe('makeSelectLoading', () => {
         loading,
       },
     };
-    expect(loadingSelector(mockedState)).toEqual(loading);
+    expect(makeSelectLoading(mockedState)).toEqual(loading);
   });
-});
 
-describe('makeSelectError', () => {
-  const errorSelector = makeSelectError();
   it('should select the error', () => {
     const error = 404;
     const mockedState = {
@@ -65,12 +53,9 @@ describe('makeSelectError', () => {
         error,
       },
     };
-    expect(errorSelector(mockedState)).toEqual(error);
+    expect(makeSelectError(mockedState)).toEqual(error);
   });
-});
 
-describe('makeSelectLocation', () => {
-  const locationStateSelector = makeSelectLocation();
   it('should select the location', () => {
     const route = {
       location: { pathname: '/foo' },
@@ -78,6 +63,6 @@ describe('makeSelectLocation', () => {
     const mockedState = {
       route,
     };
-    expect(locationStateSelector(mockedState)).toEqual(route.location);
+    expect(makeSelectLocation(mockedState)).toEqual(route.location);
   });
 });

--- a/app/containers/App/actions.js
+++ b/app/containers/App/actions.js
@@ -91,7 +91,6 @@ export const progress = payload => ({
 
 export const resetProgress = () => ({
   type: RESET_PROGRESS,
-  payload: 0,
 });
 
 export const completeProgress = () => ({

--- a/app/containers/App/reducer.js
+++ b/app/containers/App/reducer.js
@@ -24,8 +24,10 @@ export const initialState = {
   error: false,
   errorMessage: '',
   loading: false,
-  maxProgressCount: 0,
-  progress: 0,
+  progress: {
+    current: 0,
+    max: 1,
+  },
   status: undefined,
   userName: undefined,
   userScopes: [],
@@ -77,23 +79,23 @@ export default (state = initialState, action) =>
         break;
 
       case PROGRESS:
-        draft.progress = payload;
+        draft.progress.current = payload;
         break;
 
       case RESET_PROGRESS:
-        draft.progress = 0;
+        draft.progress.current = 0;
         break;
 
       case COMPLETE_PROGRESS:
-        draft.progress = state.maxProgressCount;
+        draft.progress.current = state.progress.max;
         break;
 
       case INCREMENT_PROGRESS:
-        draft.progress += 1;
+        draft.progress.current += 1;
         break;
 
       case MAX_PROGRESS_COUNT:
-        draft.maxProgressCount = payload;
+        draft.progress.max = payload;
         break;
 
       case LOAD_BAG_DATA:

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -1,14 +1,13 @@
 import { createSelector } from 'reselect';
 import { initialState } from './reducer';
 
-const selectGlobal = state => state.global || initialState;
+const selectGlobal = state => (state && state.global) || initialState;
 const selectRoute = state => state.route;
 
-const makeSelectStatus = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.status,
-  );
+const makeSelectStatus = createSelector(
+  selectGlobal,
+  globalState => globalState.status,
+);
 
 const makeSelectUserName = createSelector(
   selectGlobal,
@@ -47,10 +46,7 @@ const makeSelectIsAuthenticated = createSelector(
 
 const makeSelectProgress = createSelector(
   selectGlobal,
-  ({ progress, maxProgressCount }) => ({
-    current: progress,
-    max: maxProgressCount,
-  }),
+  ({ progress }) => progress,
 );
 
 export {

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -10,56 +10,48 @@ const makeSelectStatus = () =>
     globalState => globalState.status,
   );
 
-const makeSelectUserName = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.userName,
-  );
+const makeSelectUserName = createSelector(
+  selectGlobal,
+  globalState => globalState.userName,
+);
 
-const makeSelectAccessToken = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.accessToken,
-  );
+const makeSelectAccessToken = createSelector(
+  selectGlobal,
+  globalState => globalState.accessToken,
+);
 
-const makeSelectLoading = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.loading,
-  );
+const makeSelectLoading = createSelector(
+  selectGlobal,
+  globalState => globalState.loading,
+);
 
-const makeSelectError = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.error,
-  );
+const makeSelectError = createSelector(
+  selectGlobal,
+  globalState => globalState.error,
+);
 
-const makeSelectErrorMessage = () =>
-  createSelector(
-    selectGlobal,
-    globalState => globalState.errorMessage,
-  );
+const makeSelectErrorMessage = createSelector(
+  selectGlobal,
+  globalState => globalState.errorMessage,
+);
 
-const makeSelectLocation = () =>
-  createSelector(
-    selectRoute,
-    routeState => routeState.location,
-  );
+const makeSelectLocation = createSelector(
+  selectRoute,
+  routeState => routeState.location,
+);
 
-const makeSelectIsAuthenticated = () =>
-  createSelector(
-    selectGlobal,
-    globalState => !globalState.accessToken === false,
-  );
+const makeSelectIsAuthenticated = createSelector(
+  selectGlobal,
+  globalState => !globalState.accessToken === false,
+);
 
-const makeSelectProgress = () =>
-  createSelector(
-    selectGlobal,
-    ({ progress, maxProgressCount }) => ({
-      current: progress,
-      max: maxProgressCount,
-    }),
-  );
+const makeSelectProgress = createSelector(
+  selectGlobal,
+  ({ progress, maxProgressCount }) => ({
+    current: progress,
+    max: maxProgressCount,
+  }),
+);
 
 export {
   makeSelectAccessToken,

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -1,63 +1,50 @@
 import { createSelector } from 'reselect';
 import { initialState } from './reducer';
 
-const selectGlobal = state => (state && state.global) || initialState;
-const selectRoute = state => state.route;
+export const selectGlobal = state => (state && state.global) || initialState;
+const selectRoute = state => (state && state.route) || { location: '/' };
 
-const makeSelectStatus = createSelector(
+export const makeSelectStatus = createSelector(
   selectGlobal,
-  globalState => globalState.status,
+  ({ status }) => status,
 );
 
-const makeSelectUserName = createSelector(
+export const makeSelectUserName = createSelector(
   selectGlobal,
-  globalState => globalState.userName,
+  ({ userName }) => userName,
 );
 
-const makeSelectAccessToken = createSelector(
+export const makeSelectAccessToken = createSelector(
   selectGlobal,
-  globalState => globalState.accessToken,
+  ({ accessToken }) => accessToken,
 );
 
-const makeSelectLoading = createSelector(
+export const makeSelectLoading = createSelector(
   selectGlobal,
-  globalState => globalState.loading,
+  ({ loading }) => loading,
 );
 
-const makeSelectError = createSelector(
+export const makeSelectError = createSelector(
   selectGlobal,
-  globalState => globalState.error,
+  ({ error }) => error,
 );
 
-const makeSelectErrorMessage = createSelector(
+export const makeSelectErrorMessage = createSelector(
   selectGlobal,
-  globalState => globalState.errorMessage,
+  ({ errorMessage }) => errorMessage,
 );
 
-const makeSelectLocation = createSelector(
+export const makeSelectLocation = createSelector(
   selectRoute,
-  routeState => routeState.location,
+  ({ location }) => location,
 );
 
-const makeSelectIsAuthenticated = createSelector(
+export const makeSelectIsAuthenticated = createSelector(
   selectGlobal,
-  globalState => !globalState.accessToken === false,
+  ({ accessToken }) => !!accessToken,
 );
 
-const makeSelectProgress = createSelector(
+export const makeSelectProgress = createSelector(
   selectGlobal,
   ({ progress }) => progress,
 );
-
-export {
-  makeSelectAccessToken,
-  makeSelectError,
-  makeSelectErrorMessage,
-  makeSelectIsAuthenticated,
-  makeSelectLoading,
-  makeSelectLocation,
-  makeSelectProgress,
-  makeSelectStatus,
-  makeSelectUserName,
-  selectGlobal,
-};

--- a/app/containers/CSVDownload/index.js
+++ b/app/containers/CSVDownload/index.js
@@ -198,16 +198,16 @@ CSVDownloadContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  OPENBARE_RUIMTE: makeSelectOpenbareRuimteData(),
-  WOONPLAATS: makeSelectWoonplaatsData(),
-  NUMMERAANDUIDING: makeSelectNummeraanduidingData(),
-  VERBLIJFSOBJECT: makeSelectVerblijfsobjectData(),
-  PAND: makeSelectPandData(),
-  KADASTRAAL_OBJECT: makeSelectKadastraalObjectData(),
-  KADASTRAAL_SUBJECT_NNP: makeSelectKadastraalSubjectNNPData(),
-  KADASTRAAL_SUBJECT_NP: makeSelectKadastraalSubjectNPData(),
-  VESTIGING: makeSelectVestigingData(),
-  GEBIED: makeSelectGebiedData(),
+  OPENBARE_RUIMTE: makeSelectOpenbareRuimteData,
+  WOONPLAATS: makeSelectWoonplaatsData,
+  NUMMERAANDUIDING: makeSelectNummeraanduidingData,
+  VERBLIJFSOBJECT: makeSelectVerblijfsobjectData,
+  PAND: makeSelectPandData,
+  KADASTRAAL_OBJECT: makeSelectKadastraalObjectData,
+  KADASTRAAL_SUBJECT_NNP: makeSelectKadastraalSubjectNNPData,
+  KADASTRAAL_SUBJECT_NP: makeSelectKadastraalSubjectNPData,
+  VESTIGING: makeSelectVestigingData,
+  GEBIED: makeSelectGebiedData,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Gebied/index.js
+++ b/app/containers/Gebied/index.js
@@ -30,8 +30,8 @@ GebiedContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectGebiedData(),
-  status: makeSelectStatus(),
+  data: makeSelectGebiedData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/GlobalError/index.js
+++ b/app/containers/GlobalError/index.js
@@ -86,8 +86,8 @@ GlobalError.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  error: makeSelectError(),
-  errorMessage: makeSelectErrorMessage(),
+  error: makeSelectError,
+  errorMessage: makeSelectErrorMessage,
 });
 
 export const mapDispatchToProps = dispatch =>

--- a/app/containers/Header/index.js
+++ b/app/containers/Header/index.js
@@ -38,7 +38,7 @@ HeaderContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  userName: makeSelectUserName(),
+  userName: makeSelectUserName,
 });
 
 export const mapDispatchToProps = dispatch =>

--- a/app/containers/KadastraalObject/index.js
+++ b/app/containers/KadastraalObject/index.js
@@ -31,8 +31,8 @@ KadastraalObjectContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectKadastraalObjectData(),
-  status: makeSelectStatus(),
+  data: makeSelectKadastraalObjectData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/KadastraalObject/selectors.js
+++ b/app/containers/KadastraalObject/selectors.js
@@ -2,39 +2,39 @@ import { createSelector } from 'reselect';
 
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData, isArray, isAppartment } from 'utils';
+import { initialState } from './reducer';
 
-const selectKadastraalObject = state => state.kadastraalObject;
+const selectKadastraalObject = state => (state && state.kadastraalObject) || initialState;
 
-export const makeSelectKadastraalObjectData = () =>
-  createSelector(
-    selectKadastraalObject,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectKadastraalObjectData = createSelector(
+  selectKadastraalObject,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!state.data) {
-        return state.data;
-      }
+    if (!state.data) {
+      return state.data;
+    }
 
-      const { data: { results } = {} } = state;
+    const { data: { results } = {} } = state;
 
-      const keys = ['id', 'in_onderzoek', 'koopjaar', 'koopsom', 'objectnummer', 'aanduiding'];
+    const keys = ['id', 'in_onderzoek', 'koopjaar', 'koopsom', 'objectnummer', 'aanduiding'];
 
-      if (results) {
-        return results.map(object => formatData({ data: object, keys, locale }));
-      }
+    if (results) {
+      return results.map(object => formatData({ data: object, keys, locale }));
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (data.id) {
-        return formatData({ data, keys });
-      }
+    if (data.id) {
+      return formatData({ data, keys });
+    }
 
-      return null;
-    },
-  );
+    return null;
+  },
+);
 
 export const makeSelectFromObjectAppartment = key =>
   createSelector(

--- a/app/containers/KadastraalSubjectNNP/index.js
+++ b/app/containers/KadastraalSubjectNNP/index.js
@@ -35,8 +35,8 @@ KadastraalSubjectNNPContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectKadastraalSubjectNNPData(),
-  status: makeSelectStatus(),
+  data: makeSelectKadastraalSubjectNNPData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/KadastraalSubjectNNP/selectors.js
+++ b/app/containers/KadastraalSubjectNNP/selectors.js
@@ -2,39 +2,39 @@ import { createSelector } from 'reselect';
 
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData, isArray, isValidSubjectNNP } from 'utils';
+import { initialState } from './reducer';
 
-const selectKadastraalSubjectNNP = state => state.kadastraalSubjectNNP;
+const selectKadastraalSubjectNNP = state => (state && state.kadastraalSubjectNNP) || initialState;
 
 /**
  * Niet-natuurlijk persoon
  */
-export const makeSelectKadastraalSubjectNNPData = () =>
-  createSelector(
-    selectKadastraalSubjectNNP,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectKadastraalSubjectNNPData = createSelector(
+  selectKadastraalSubjectNNP,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!state.data) {
-        return state.data;
-      }
+    if (!state.data) {
+      return state.data;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (!isArray(data) || !data.length) {
-        return data;
-      }
+    if (!isArray(data) || !data.length) {
+      return data;
+    }
 
-      const keys = ['kvknummer', 'rechtsvorm', 'rsin', 'statutaire_naam'];
+    const keys = ['kvknummer', 'rechtsvorm', 'rsin', 'statutaire_naam'];
 
-      const results = data.filter(isValidSubjectNNP).map(subject => formatData({ data: subject, keys, locale }));
+    const results = data.filter(isValidSubjectNNP).map(subject => formatData({ data: subject, keys, locale }));
 
-      if (!results.length) {
-        return null;
-      }
+    if (!results.length) {
+      return null;
+    }
 
-      return results;
-    },
-  );
+    return results;
+  },
+);

--- a/app/containers/KadastraalSubjectNP/index.js
+++ b/app/containers/KadastraalSubjectNP/index.js
@@ -35,8 +35,8 @@ KadastraalSubjectNPContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectKadastraalSubjectNPData(),
-  status: makeSelectStatus(),
+  data: makeSelectKadastraalSubjectNPData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/KadastraalSubjectNP/selectors.js
+++ b/app/containers/KadastraalSubjectNP/selectors.js
@@ -2,48 +2,48 @@ import { createSelector } from 'reselect';
 
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData, isArray, isValidSubjectNP } from 'utils';
+import { initialState } from './reducer';
 
-const selectKadastraalSubjectNP = state => state.kadastraalSubjectNP;
+const selectKadastraalSubjectNP = state => (state && state.kadastraalSubjectNP) || initialState;
 
 /**
  * Natuurlijk persoon
  */
-export const makeSelectKadastraalSubjectNPData = () =>
-  createSelector(
-    selectKadastraalSubjectNP,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectKadastraalSubjectNPData = createSelector(
+  selectKadastraalSubjectNP,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!state.data) {
-        return state.data;
-      }
+    if (!state.data) {
+      return state.data;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (!isArray(data) || !data.length) {
-        return data;
-      }
+    if (!isArray(data) || !data.length) {
+      return data;
+    }
 
-      const keys = [
-        'geboortedatum',
-        'geboorteland',
-        'geboorteplaats',
-        'geslacht',
-        'naam',
-        'overlijdensdatum',
-        'voornamen',
-        'voorvoegsels',
-      ];
+    const keys = [
+      'geboortedatum',
+      'geboorteland',
+      'geboorteplaats',
+      'geslacht',
+      'naam',
+      'overlijdensdatum',
+      'voornamen',
+      'voorvoegsels',
+    ];
 
-      const results = data.filter(isValidSubjectNP).map(subject => formatData({ data: subject, keys, locale }));
+    const results = data.filter(isValidSubjectNP).map(subject => formatData({ data: subject, keys, locale }));
 
-      if (!results.length) {
-        return null;
-      }
+    if (!results.length) {
+      return null;
+    }
 
-      return results;
-    },
-  );
+    return results;
+  },
+);

--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -28,7 +28,7 @@ LanguageProvider.propTypes = {
 };
 
 const mapStateToProps = createSelector(
-  makeSelectLocale(),
+  makeSelectLocale,
   locale => ({ locale }),
 );
 

--- a/app/containers/LanguageProvider/selectors.js
+++ b/app/containers/LanguageProvider/selectors.js
@@ -1,18 +1,19 @@
 import { createSelector } from 'reselect';
 
+import { initialState } from './reducer';
+
 /**
  * Direct selector to the languageToggle state domain
  */
-const selectLanguage = state => state.language;
+const selectLanguage = state => (state && state.language) || initialState;
 
 /**
  * Select the language locale
  */
 
-const makeSelectLocale = () =>
-  createSelector(
-    selectLanguage,
-    languageState => languageState.locale,
-  );
+const makeSelectLocale = createSelector(
+  selectLanguage,
+  languageState => languageState.locale,
+);
 
 export { selectLanguage, makeSelectLocale };

--- a/app/containers/Ligplaats/selectors.js
+++ b/app/containers/Ligplaats/selectors.js
@@ -2,20 +2,19 @@ import { createSelector } from 'reselect';
 
 const selectLigplaats = state => state.ligplaats;
 
-export const makeSelectLIGNummeraanduidingId = () =>
-  createSelector(
-    selectLigplaats,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectLIGNummeraanduidingId = createSelector(
+  selectLigplaats,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!state.data) {
-        return state.data;
-      }
+    if (!state.data) {
+      return state.data;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      return data.hoofdadres.landelijk_id;
-    },
-  );
+    return data.hoofdadres.landelijk_id;
+  },
+);

--- a/app/containers/Ligplaats/selectors.js
+++ b/app/containers/Ligplaats/selectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 
-const selectLigplaats = state => state.ligplaats;
+import { initialState } from './reducer';
+
+const selectLigplaats = state => (state && state.ligplaats) || initialState;
 
 export const makeSelectLIGNummeraanduidingId = createSelector(
   selectLigplaats,

--- a/app/containers/MaatschappelijkeActiviteit/saga.js
+++ b/app/containers/MaatschappelijkeActiviteit/saga.js
@@ -12,7 +12,7 @@ const { API_ROOT } = configuration;
 const MA_API = `${API_ROOT}handelsregister/maatschappelijkeactiviteit/`;
 
 export function* fetchMaatschappelijkeActiviteitData() {
-  const maIds = yield select(makeSelectMaatschappelijkeActiviteitIds());
+  const maIds = yield select(makeSelectMaatschappelijkeActiviteitIds);
 
   try {
     if (maIds) {

--- a/app/containers/Map/index.js
+++ b/app/containers/Map/index.js
@@ -6,7 +6,7 @@ import { makeSelectCoordinates } from 'containers/Verblijfsobject/selectors';
 import Map from 'components/Map';
 
 const mapStateToProps = createStructuredSelector({
-  coordinates: makeSelectCoordinates(),
+  coordinates: makeSelectCoordinates,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Nummeraanduiding/index.js
+++ b/app/containers/Nummeraanduiding/index.js
@@ -37,8 +37,8 @@ NummeraanduidingContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectNummeraanduidingData(),
-  status: makeSelectStatus(),
+  data: makeSelectNummeraanduidingData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Nummeraanduiding/selectors.js
+++ b/app/containers/Nummeraanduiding/selectors.js
@@ -68,23 +68,22 @@ export const makeSelectWoonplaatsId = () =>
     },
   );
 
-export const makeSelectOpenbareRuimteId = () =>
-  createSelector(
-    selectNummeraanduiding,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectOpenbareRuimteId = createSelector(
+  selectNummeraanduiding,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (!data) {
-        return null;
-      }
+    if (!data) {
+      return null;
+    }
 
-      return data.openbare_ruimte.landelijk_id;
-    },
-  );
+    return data.openbare_ruimte.landelijk_id;
+  },
+);
 
 export const makeSelectGebiedData = () =>
   createSelector(

--- a/app/containers/Nummeraanduiding/selectors.js
+++ b/app/containers/Nummeraanduiding/selectors.js
@@ -3,70 +3,69 @@ import { createSelector } from 'reselect';
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData, isArray } from 'utils';
 
-const selectNummeraanduiding = state => state.nummeraanduiding;
+import { initialState } from './reducer';
 
-export const makeSelectNummeraanduidingData = () =>
-  createSelector(
-    selectNummeraanduiding,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+const selectNummeraanduiding = state => (state && state.nummeraanduiding) || initialState;
 
-      const { data } = state;
+export const makeSelectNummeraanduidingData = createSelector(
+  selectNummeraanduiding,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return null;
-      }
+    const { data } = state;
 
-      const keys = [
-        'adres',
-        'hoofdadres',
-        'huisletter',
-        'huisnummer',
-        'huisnummer_toevoeging',
-        'nummeraanduidingidentificatie',
-        'postcode',
-        'woonplaats',
-        'type',
-        'begin_geldigheid',
-        'einde_geldigheid',
-      ];
+    if (!data) {
+      return null;
+    }
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    const keys = [
+      'adres',
+      'hoofdadres',
+      'huisletter',
+      'huisnummer',
+      'huisnummer_toevoeging',
+      'nummeraanduidingidentificatie',
+      'postcode',
+      'woonplaats',
+      'type',
+      'begin_geldigheid',
+      'einde_geldigheid',
+    ];
 
-export const makeSelectAdres = () =>
-  createSelector(
-    makeSelectNummeraanduidingData(),
-    state => {
-      if (!state || !isArray(state) || !state.length) {
-        return undefined;
-      }
+    return formatData({ data, keys, locale });
+  },
+);
 
-      return state.filter(({ key }) => key === 'adres' || key === 'postcode');
-    },
-  );
+export const makeSelectAdres = createSelector(
+  makeSelectNummeraanduidingData,
+  state => {
+    if (!state || !isArray(state) || !state.length) {
+      return undefined;
+    }
 
-export const makeSelectWoonplaatsId = () =>
-  createSelector(
-    selectNummeraanduiding,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+    return state.filter(({ key }) => key === 'adres' || key === 'postcode');
+  },
+);
 
-      const { data } = state;
+export const makeSelectWoonplaatsId = createSelector(
+  selectNummeraanduiding,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data || !data.woonplaats || !data.woonplaats.landelijk_id) {
-        return null;
-      }
+    const { data } = state;
 
-      return data.woonplaats.landelijk_id;
-    },
-  );
+    if (!data || !data.woonplaats || !data.woonplaats.landelijk_id) {
+      return null;
+    }
+
+    return data.woonplaats.landelijk_id;
+  },
+);
 
 export const makeSelectOpenbareRuimteId = createSelector(
   selectNummeraanduiding,
@@ -85,25 +84,24 @@ export const makeSelectOpenbareRuimteId = createSelector(
   },
 );
 
-export const makeSelectGebiedData = () =>
-  createSelector(
-    selectNummeraanduiding,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectGebiedData = createSelector(
+  selectNummeraanduiding,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (!data) {
-        return null;
-      }
+    if (!data) {
+      return null;
+    }
 
-      data.wijk = data.buurtcombinatie;
+    data.wijk = data.buurtcombinatie;
 
-      const keys = ['buurt', 'wijk', 'stadsdeel'];
+    const keys = ['buurt', 'wijk', 'stadsdeel'];
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    return formatData({ data, keys, locale });
+  },
+);

--- a/app/containers/OpenbareRuimte/index.js
+++ b/app/containers/OpenbareRuimte/index.js
@@ -35,8 +35,8 @@ OpenbareRuimteContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectOpenbareRuimteData(),
-  status: makeSelectStatus(),
+  data: makeSelectOpenbareRuimteData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/OpenbareRuimte/selectors.js
+++ b/app/containers/OpenbareRuimte/selectors.js
@@ -3,25 +3,26 @@ import { createSelector } from 'reselect';
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData } from 'utils';
 
-const selectOpenbareRuimte = state => state.openbareRuimte;
+import { initialState } from './reducer';
 
-export const makeSelectOpenbareRuimteData = () =>
-  createSelector(
-    selectOpenbareRuimte,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+const selectOpenbareRuimte = state => (state && state.openbareRuimte) || initialState;
 
-      const { data } = state;
+export const makeSelectOpenbareRuimteData = createSelector(
+  selectOpenbareRuimte,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      const keys = ['naam', 'type', 'openbare_ruimte_identificatie'];
+    if (!data) {
+      return data;
+    }
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    const keys = ['naam', 'type', 'openbare_ruimte_identificatie'];
+
+    return formatData({ data, keys, locale });
+  },
+);

--- a/app/containers/Pand/index.js
+++ b/app/containers/Pand/index.js
@@ -35,8 +35,8 @@ PandContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectPandData(),
-  status: makeSelectStatus(),
+  data: makeSelectPandData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Pand/selectors.js
+++ b/app/containers/Pand/selectors.js
@@ -3,32 +3,33 @@ import { createSelector } from 'reselect';
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData } from 'utils';
 
-const selectPand = state => state.pand;
+import { initialState } from './reducer';
 
-export const makeSelectPandData = () =>
-  createSelector(
-    selectPand,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+const selectPand = state => (state && state.pand) || initialState;
 
-      const { data } = state;
+export const makeSelectPandData = createSelector(
+  selectPand,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      const keys = [
-        'hoogste_bouwlaag',
-        'laagste_bouwlaag',
-        'oorspronkelijk_bouwjaar',
-        'pandidentificatie',
-        'status',
-        'verblijfsobjecten',
-      ];
+    if (!data) {
+      return data;
+    }
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    const keys = [
+      'hoogste_bouwlaag',
+      'laagste_bouwlaag',
+      'oorspronkelijk_bouwjaar',
+      'pandidentificatie',
+      'status',
+      'verblijfsobjecten',
+    ];
+
+    return formatData({ data, keys, locale });
+  },
+);

--- a/app/containers/Progress/index.js
+++ b/app/containers/Progress/index.js
@@ -23,12 +23,12 @@ ProgressContainer.propTypes = {
     current: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
   }).isRequired,
-  status: PropTypes.string,
+  status: PropTypes.func,
 };
 
 const mapStateToProps = createStructuredSelector({
-  progress: makeSelectProgress(),
-  status: makeSelectStatus(),
+  progress: makeSelectProgress,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Progress/index.js
+++ b/app/containers/Progress/index.js
@@ -7,10 +7,12 @@ import Progress from 'components/Progress';
 import { makeSelectProgress, makeSelectStatus } from 'containers/App/selectors';
 import { LOAD_DATA_FAILED } from 'containers/App/constants';
 
-const ProgressContainer = ({ progress: { current, max }, status }) => {
+const ProgressContainer = ({ progress, status }) => {
+  const { current, max } = progress;
   const statusFailed = status === LOAD_DATA_FAILED;
   const className = statusFailed ? 'finished' : '';
   const now = statusFailed ? 1 : current / max;
+
   return <Progress now={now} labelPosition="bottom" className={className} />;
 };
 
@@ -23,7 +25,7 @@ ProgressContainer.propTypes = {
     current: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
   }).isRequired,
-  status: PropTypes.func,
+  status: PropTypes.string,
 };
 
 const mapStateToProps = createStructuredSelector({

--- a/app/containers/Search/index.js
+++ b/app/containers/Search/index.js
@@ -135,7 +135,7 @@ SearchContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  results: makeSelectResults(),
+  results: makeSelectResults,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/app/containers/Search/reducer.js
+++ b/app/containers/Search/reducer.js
@@ -3,10 +3,14 @@ import { SEARCH_SELECT, INPUT_CHANGE, TYPE_AHEAD_SUCCESS, TYPE_AHEAD_FAILED } fr
 
 // The initial state of the App
 export const initialState = {
+  brkId: undefined,
   error: false,
+  errorMessage: '',
   input: '',
+  ligId: undefined,
   loading: false,
   results: [],
+  vboId: undefined,
 };
 
 /* eslint-disable default-case, no-param-reassign */
@@ -30,7 +34,8 @@ export default (state = initialState, action) =>
         break;
 
       case TYPE_AHEAD_FAILED:
-        draft.error = action.payload;
+        draft.error = true;
+        draft.errorMessage = action.payload;
         break;
     }
   });

--- a/app/containers/Search/selectors.js
+++ b/app/containers/Search/selectors.js
@@ -1,32 +1,32 @@
 import { createSelector } from 'reselect';
+import { initialState } from './reducer';
 
-const selectSearch = state => state.search;
+const selectSearch = state => (state && state.search) || initialState;
 
-export const makeSelectResults = () =>
-  createSelector(
-    selectSearch,
-    state => {
-      const { results } = state;
+export const makeSelectResults = createSelector(
+  selectSearch,
+  state => {
+    const { results } = state;
 
-      if (!results || !results.length) {
-        return undefined;
-      }
+    if (!results || !results.length) {
+      return undefined;
+    }
 
-      const reId = uri => /([^/]+)\W$/.exec(uri)[1];
-      const isVBO = uri => /verblijfsobject/.test(uri);
-      const isLIG = uri => /ligplaats/.test(uri);
-      const isBRK = uri => /object/.test(uri);
-      const mappedResults = {};
+    const reId = uri => /([^/]+)\W$/.exec(uri)[1];
+    const isVBO = uri => /verblijfsobject/.test(uri);
+    const isLIG = uri => /ligplaats/.test(uri);
+    const isBRK = uri => /object/.test(uri);
+    const mappedResults = {};
 
-      results.forEach(({ content, label }) => {
-        mappedResults[label] = content.map(({ uri, _display }) => ({
-          name: _display,
-          vboId: isVBO(uri) ? reId(uri) : null,
-          ligId: isLIG(uri) ? reId(uri) : null,
-          brkId: isBRK(uri) ? reId(uri) : null,
-        }));
-      });
+    results.forEach(({ content, label }) => {
+      mappedResults[label] = content.map(({ uri, _display }) => ({
+        name: _display,
+        vboId: isVBO(uri) ? reId(uri) : null,
+        ligId: isLIG(uri) ? reId(uri) : null,
+        brkId: isBRK(uri) ? reId(uri) : null,
+      }));
+    });
 
-      return mappedResults;
-    },
-  );
+    return mappedResults;
+  },
+);

--- a/app/containers/Summary/index.js
+++ b/app/containers/Summary/index.js
@@ -7,7 +7,7 @@ import Summary from 'components/Summary';
 import { makeSelectSummary } from './selectors';
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectSummary(),
+  data: makeSelectSummary,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Summary/selectors.js
+++ b/app/containers/Summary/selectors.js
@@ -9,124 +9,123 @@ import { makeSelectKadastraalObjectData } from 'containers/KadastraalObject/sele
 import { makeSelectKadastraalSubjectNNPData } from 'containers/KadastraalSubjectNNP/selectors';
 import { makeSelectOpenbareRuimteData } from 'containers/OpenbareRuimte/selectors';
 
-export const makeSelectSummary = () =>
-  createSelector(
-    [
-      makeSelectAdres(),
-      makeSelectVerblijfsobjectData(),
-      makeSelectNummeraanduidingData(),
-      makeSelectPandData(),
-      makeSelectKadastraalObjectData(),
-      makeSelectKadastraalSubjectNNPData(),
-      makeSelectOpenbareRuimteData(),
-    ],
-    (adr = [], vbo = [], num = [], pnd = [], brko = [], nnp = [], opr = []) => {
-      const summary = {};
+export const makeSelectSummary = createSelector(
+  [
+    makeSelectAdres,
+    makeSelectVerblijfsobjectData,
+    makeSelectNummeraanduidingData,
+    makeSelectPandData,
+    makeSelectKadastraalObjectData,
+    makeSelectKadastraalSubjectNNPData,
+    makeSelectOpenbareRuimteData,
+  ],
+  (adr = [], vbo = [], num = [], pnd = [], brko = [], nnp = [], opr = []) => {
+    const summary = {};
 
-      const getValue = (dataset, id, valueSeparator = ', ') => {
-        const values = new Set();
+    const getValue = (dataset, id, valueSeparator = ', ') => {
+      const values = new Set();
 
-        dataset.forEach(item => {
-          if (isObject(item) && !!item.key && item.key === id) {
-            values.add(item.value);
-          } else if (isArray(item)) {
-            const matchingItem = item.find(({ key }) => key === id);
+      dataset.forEach(item => {
+        if (isObject(item) && !!item.key && item.key === id) {
+          values.add(item.value);
+        } else if (isArray(item)) {
+          const matchingItem = item.find(({ key }) => key === id);
 
-            if (matchingItem) {
-              values.add(matchingItem.value);
-            }
+          if (matchingItem) {
+            values.add(matchingItem.value);
           }
-        });
+        }
+      });
 
-        const valuesArray = Array.from(values);
+      const valuesArray = Array.from(values);
 
-        return valueSeparator ? valuesArray.join(valueSeparator) : valuesArray;
+      return valueSeparator ? valuesArray.join(valueSeparator) : valuesArray;
+    };
+
+    if (adr && adr.length) {
+      const adres = getValue(adr, 'adres');
+      const postcode = getValue(adr, 'postcode');
+
+      summary.address = {
+        label: messages.address,
+        value: [adres, ' ', postcode],
       };
+    }
 
-      if (adr && adr.length) {
-        const adres = getValue(adr, 'adres');
-        const postcode = getValue(adr, 'postcode');
+    if (opr && opr.length) {
+      const oprId = getValue(opr, 'openbare_ruimte_identificatie');
 
-        summary.address = {
-          label: messages.address,
-          value: [adres, ' ', postcode],
+      summary.public_space_id = {
+        label: messages.public_space_id,
+        value: oprId,
+      };
+    }
+
+    if (num && num.length) {
+      const numId = getValue(num, 'nummeraanduidingidentificatie');
+
+      summary.number_identification_id = {
+        label: messages.number_identification_id,
+        value: numId,
+      };
+    }
+
+    if (vbo && vbo.length) {
+      const vboId = getValue(vbo, 'verblijfsobjectidentificatie');
+
+      summary.accommodation_object_id = {
+        label: messages.accommodation_object_id,
+        value: vboId,
+      };
+    }
+
+    if (pnd && pnd.length) {
+      const pndId = getValue(pnd, 'pandidentificatie');
+
+      summary.house_id = {
+        label: messages.house_id,
+        value: pndId,
+      };
+    }
+
+    if (brko && brko.length) {
+      const objectNrs = getValue(brko, 'aanduiding', null);
+
+      if (objectNrs.length) {
+        const label =
+          objectNrs.length > 1 ? messages.cadastral_object_indications : messages.cadastral_object_indication;
+
+        summary.cadastral_object_nr = {
+          label,
+          value: objectNrs.join(', '),
+        };
+      }
+    }
+
+    if (nnp && nnp.length) {
+      const kvkNrs = getValue(nnp, 'kvknummer', null);
+
+      if (kvkNrs.length) {
+        const kvkNrsLabel = kvkNrs.length > 1 ? messages.chamber_of_commerce_nrs : messages.chamber_of_commerce_nr;
+
+        summary.chamber_of_commerce_nr = {
+          label: kvkNrsLabel,
+          value: kvkNrs.join(', '),
         };
       }
 
-      if (opr && opr.length) {
-        const oprId = getValue(opr, 'openbare_ruimte_identificatie');
+      const rsinNrs = getValue(nnp, 'rsin', null);
 
-        summary.public_space_id = {
-          label: messages.public_space_id,
-          value: oprId,
+      if (rsinNrs.length) {
+        const rsinNrsLabel = rsinNrs.length > 1 ? messages.rsins : messages.rsin;
+
+        summary.RSIN = {
+          label: rsinNrsLabel,
+          value: rsinNrs.join(', '),
         };
       }
+    }
 
-      if (num && num.length) {
-        const numId = getValue(num, 'nummeraanduidingidentificatie');
-
-        summary.number_identification_id = {
-          label: messages.number_identification_id,
-          value: numId,
-        };
-      }
-
-      if (vbo && vbo.length) {
-        const vboId = getValue(vbo, 'verblijfsobjectidentificatie');
-
-        summary.accommodation_object_id = {
-          label: messages.accommodation_object_id,
-          value: vboId,
-        };
-      }
-
-      if (pnd && pnd.length) {
-        const pndId = getValue(pnd, 'pandidentificatie');
-
-        summary.house_id = {
-          label: messages.house_id,
-          value: pndId,
-        };
-      }
-
-      if (brko && brko.length) {
-        const objectNrs = getValue(brko, 'aanduiding', null);
-
-        if (objectNrs.length) {
-          const label =
-            objectNrs.length > 1 ? messages.cadastral_object_indications : messages.cadastral_object_indication;
-
-          summary.cadastral_object_nr = {
-            label,
-            value: objectNrs.join(', '),
-          };
-        }
-      }
-
-      if (nnp && nnp.length) {
-        const kvkNrs = getValue(nnp, 'kvknummer', null);
-
-        if (kvkNrs.length) {
-          const kvkNrsLabel = kvkNrs.length > 1 ? messages.chamber_of_commerce_nrs : messages.chamber_of_commerce_nr;
-
-          summary.chamber_of_commerce_nr = {
-            label: kvkNrsLabel,
-            value: kvkNrs.join(', '),
-          };
-        }
-
-        const rsinNrs = getValue(nnp, 'rsin', null);
-
-        if (rsinNrs.length) {
-          const rsinNrsLabel = rsinNrs.length > 1 ? messages.rsins : messages.rsin;
-
-          summary.RSIN = {
-            label: rsinNrsLabel,
-            value: rsinNrs.join(', '),
-          };
-        }
-      }
-
-      return summary;
-    },
-  );
+    return summary;
+  },
+);

--- a/app/containers/TOC/index.js
+++ b/app/containers/TOC/index.js
@@ -12,7 +12,7 @@ import reducer from './reducer';
 const Intl = injectIntl(TOC);
 
 const mapStateToProps = createStructuredSelector({
-  sections: makeSelectTOC(),
+  sections: makeSelectTOC,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/TOC/reducer.js
+++ b/app/containers/TOC/reducer.js
@@ -14,6 +14,7 @@ import { OBJECTS, LOAD_BAG_DATA } from 'containers/App/constants';
 export const initialState = {
   loading: false,
   error: false,
+  toc: [],
 };
 
 /* eslint-disable default-case, no-param-reassign */

--- a/app/containers/TOC/selectors.js
+++ b/app/containers/TOC/selectors.js
@@ -1,15 +1,16 @@
 import { createSelector } from 'reselect';
 
-const selectTOC = state => state.toc;
+import { initialState } from './reducer';
 
-export const makeSelectTOC = () =>
-  createSelector(
-    selectTOC,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+const selectTOC = state => (state && state.toc) || initialState;
 
-      return state.toc;
-    },
-  );
+export const makeSelectTOC = createSelector(
+  selectTOC,
+  state => {
+    if (!state) {
+      return undefined;
+    }
+
+    return state.toc;
+  },
+);

--- a/app/containers/Verblijfsobject/index.js
+++ b/app/containers/Verblijfsobject/index.js
@@ -34,8 +34,8 @@ VerblijfsObjectContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectVerblijfsobjectData(),
-  status: makeSelectStatus(),
+  data: makeSelectVerblijfsobjectData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Verblijfsobject/saga.js
+++ b/app/containers/Verblijfsobject/saga.js
@@ -10,13 +10,14 @@ import { LOAD_DATA, LOAD_ID } from './constants';
 
 const { API_ROOT } = configuration;
 const VERBLIJFSOBJECT_API = `${API_ROOT}bag/verblijfsobject/`;
+export const API_BY_BRK_OBJECT_ID = `${VERBLIJFSOBJECT_API}?kadastrale_objecten__id=`;
 
 // eslint-disable-next-line consistent-return
 export function* fetchVerblijfsobjectId(adresseerbaarObjectId) {
   try {
     const data = yield call(
       request,
-      `${VERBLIJFSOBJECT_API}?kadastrale_objecten__id=${encodeURIComponent(adresseerbaarObjectId)}`,
+      `${API_BY_BRK_OBJECT_ID}${encodeURIComponent(adresseerbaarObjectId)}`,
       getRequestOptions(),
     );
 

--- a/app/containers/Verblijfsobject/selectors.js
+++ b/app/containers/Verblijfsobject/selectors.js
@@ -1,62 +1,63 @@
 import { createSelector } from 'reselect';
 
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
+import { initialState as ligplaatsInitialState } from 'containers/Ligplaats/reducer';
 import { formatData } from 'utils';
 
-const selectVerblijfsobject = state => state.verblijfsobject;
-const selectLigplaats = state => state.ligplaats;
+import { initialState } from './reducer';
 
-export const makeSelectVerblijfsobjectData = () =>
-  createSelector(
-    selectVerblijfsobject,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+const selectVerblijfsobject = state => (state && state.verblijfsobject) || initialState;
+const selectLigplaats = state => (state && state.ligplaats) || ligplaatsInitialState;
 
-      const { data } = state;
+export const makeSelectVerblijfsobjectData = createSelector(
+  selectVerblijfsobject,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      const keys = [
-        'aanduiding_in_onderzoek',
-        'aantal_kamers',
-        'bouwlagen',
-        'eigendomsverhouding',
-        'gebruik',
-        'gebruiksdoelen',
-        'indicatie_geconstateerd',
-        'oppervlakte',
-        'status',
-        'toegang',
-        'verblijfsobjectidentificatie',
-        'verhuurbare_eenheden',
-      ];
+    if (!data) {
+      return data;
+    }
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    const keys = [
+      'aanduiding_in_onderzoek',
+      'aantal_kamers',
+      'bouwlagen',
+      'eigendomsverhouding',
+      'gebruik',
+      'gebruiksdoelen',
+      'indicatie_geconstateerd',
+      'oppervlakte',
+      'status',
+      'toegang',
+      'verblijfsobjectidentificatie',
+      'verhuurbare_eenheden',
+    ];
 
-export const makeSelectVerblijfsobjectId = () =>
-  createSelector(
-    selectVerblijfsobject,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+    return formatData({ data, keys, locale });
+  },
+);
 
-      const { data } = state;
+export const makeSelectVerblijfsobjectId = createSelector(
+  selectVerblijfsobject,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      return data.verblijfsobjectidentificatie;
-    },
-  );
+    if (!data) {
+      return data;
+    }
+
+    return data.verblijfsobjectidentificatie;
+  },
+);
 
 export const makeSelectVBONummeraanduidingId = createSelector(
   selectVerblijfsobject,
@@ -75,33 +76,32 @@ export const makeSelectVBONummeraanduidingId = createSelector(
   },
 );
 
-export const makeSelectCoordinates = () =>
-  createSelector(
-    selectVerblijfsobject,
-    selectLigplaats,
-    (vbo, lig) => {
-      const hasVboData = !!vbo && !!vbo.data;
-      const hasLigData = !!lig && !!lig.data;
-      if (!hasVboData && !hasLigData) {
-        return undefined;
-      }
+export const makeSelectCoordinates = createSelector(
+  selectVerblijfsobject,
+  selectLigplaats,
+  (vbo, lig) => {
+    const hasVboData = !!vbo && !!vbo.data;
+    const hasLigData = !!lig && !!lig.data;
+    if (!hasVboData && !hasLigData) {
+      return undefined;
+    }
 
-      const data = vbo.data || lig.data;
+    const data = vbo.data || lig.data;
 
-      if (!data || (!data.bbox && !data.geometrie)) {
-        return undefined;
-      }
+    if (!data || (!data.bbox && !data.geometrie)) {
+      return undefined;
+    }
 
-      let x;
-      let y;
+    let x;
+    let y;
 
-      if (data.geometrie.type === 'Point') {
-        [x, y] = data.geometrie.coordinates;
-      } else {
-        x = Math.floor((data.bbox[2] + data.bbox[0]) / 2);
-        y = Math.floor((data.bbox[3] + data.bbox[1]) / 2);
-      }
+    if (data.geometrie.type === 'Point') {
+      [x, y] = data.geometrie.coordinates;
+    } else {
+      x = Math.floor((data.bbox[2] + data.bbox[0]) / 2);
+      y = Math.floor((data.bbox[3] + data.bbox[1]) / 2);
+    }
 
-      return { x, y };
-    },
-  );
+    return { x, y };
+  },
+);

--- a/app/containers/Verblijfsobject/selectors.js
+++ b/app/containers/Verblijfsobject/selectors.js
@@ -58,23 +58,22 @@ export const makeSelectVerblijfsobjectId = () =>
     },
   );
 
-export const makeSelectVBONummeraanduidingId = () =>
-  createSelector(
-    selectVerblijfsobject,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+export const makeSelectVBONummeraanduidingId = createSelector(
+  selectVerblijfsobject,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      const { data } = state;
+    const { data } = state;
 
-      if (!data) {
-        return data;
-      }
+    if (!data) {
+      return data;
+    }
 
-      return data.hoofdadres.landelijk_id;
-    },
-  );
+    return data.hoofdadres.landelijk_id;
+  },
+);
 
 export const makeSelectCoordinates = () =>
   createSelector(

--- a/app/containers/Vestiging/index.js
+++ b/app/containers/Vestiging/index.js
@@ -38,8 +38,8 @@ VestigingContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectVestigingData(),
-  status: makeSelectStatus(),
+  data: makeSelectVestigingData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Vestiging/saga.js
+++ b/app/containers/Vestiging/saga.js
@@ -20,7 +20,7 @@ const { API_ROOT } = configuration;
 const VESTIGING_API = `${API_ROOT}handelsregister/vestiging/`;
 
 export function* fetchVestigingIdData() {
-  const vboId = yield select(makeSelectVerblijfsobjectId());
+  const vboId = yield select(makeSelectVerblijfsobjectId);
 
   try {
     if (vboId) {

--- a/app/containers/Vestiging/selectors.js
+++ b/app/containers/Vestiging/selectors.js
@@ -1,66 +1,69 @@
 import { createSelector } from 'reselect';
+
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
+import { initialState as maatschappelijkeActiviteitInitialState } from 'containers/MaatschappelijkeActiviteit/reducer';
 import { formatData } from 'utils';
 
-const selectVestiging = state => state.vestiging;
-const selectMaatschappelijkeActiviteit = state => state.maatschappelijkeActiviteit;
+import { initialState } from './reducer';
 
-export const makeSelectVestigingData = () =>
-  createSelector(
-    selectVestiging,
-    selectMaatschappelijkeActiviteit,
-    makeSelectLocale(),
-    (vestiging, maatschappelijkeActiviteit, locale) => {
-      if (!vestiging || !maatschappelijkeActiviteit) {
-        return undefined;
-      }
+const selectVestiging = state => (state && state.vestiging) || initialState;
+const selectMaatschappelijkeActiviteit = state =>
+  (state && state.maatschappelijkeActiviteit) || maatschappelijkeActiviteitInitialState;
 
-      if (!vestiging.data || !maatschappelijkeActiviteit.data) {
-        return undefined;
-      }
+export const makeSelectVestigingData = createSelector(
+  selectVestiging,
+  selectMaatschappelijkeActiviteit,
+  makeSelectLocale,
+  (vestiging, maatschappelijkeActiviteit, locale) => {
+    if (!vestiging || !maatschappelijkeActiviteit) {
+      return undefined;
+    }
 
-      const keys = [
-        'activiteiten',
-        'vestigingsnummer',
-        'naam',
-        'datum_aanvang',
-        'kvk_nummer',
-        'postadres',
-        'bezoekadres',
-        'activiteiten.activiteitsomschrijving',
-        'activiteiten.sbi_code',
-        'activiteiten.sbi_omschrijving',
-      ];
+    if (!vestiging.data || !maatschappelijkeActiviteit.data) {
+      return undefined;
+    }
 
-      const data = vestiging.data.map((obj, index) => {
-        const vestigingObj = { ...obj };
-        const maatschappelijkeActiviteitObj = maatschappelijkeActiviteit.data[index];
+    const keys = [
+      'activiteiten',
+      'vestigingsnummer',
+      'naam',
+      'datum_aanvang',
+      'kvk_nummer',
+      'postadres',
+      'bezoekadres',
+      'activiteiten.activiteitsomschrijving',
+      'activiteiten.sbi_code',
+      'activiteiten.sbi_omschrijving',
+    ];
 
-        vestigingObj.kvk_nummer = maatschappelijkeActiviteitObj.kvk_nummer;
-        vestigingObj.postadres = vestigingObj.postadres.volledig_adres;
-        vestigingObj.bezoekadres = vestigingObj.bezoekadres.volledig_adres;
+    const data = vestiging.data.map((obj, index) => {
+      const vestigingObj = { ...obj };
+      const maatschappelijkeActiviteitObj = maatschappelijkeActiviteit.data[index];
 
-        return vestigingObj;
-      });
+      vestigingObj.kvk_nummer = maatschappelijkeActiviteitObj.kvk_nummer;
+      vestigingObj.postadres = vestigingObj.postadres.volledig_adres;
+      vestigingObj.bezoekadres = vestigingObj.bezoekadres.volledig_adres;
 
-      return data.map(dataObj => formatData({ data: dataObj, keys, locale }));
-    },
-  );
+      return vestigingObj;
+    });
 
-export const makeSelectMaatschappelijkeActiviteitIds = () =>
-  createSelector(
-    selectVestiging,
-    state => {
-      if (!state) {
-        return undefined;
-      }
+    return data.map(dataObj => formatData({ data: dataObj, keys, locale }));
+  },
+);
 
-      const { data } = state;
+export const makeSelectMaatschappelijkeActiviteitIds = createSelector(
+  selectVestiging,
+  state => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      return data.map(({ maatschappelijke_activiteit: ma }) => ma.replace(/(?:[^\d]+)(\d+)(?:[^\d]*)/, '$1'));
-    },
-  );
+    if (!data) {
+      return data;
+    }
+
+    return data.map(({ maatschappelijke_activiteit: ma }) => ma.replace(/(?:[^\d]+)(\d+)(?:[^\d]*)/, '$1'));
+  },
+);

--- a/app/containers/Woonplaats/index.js
+++ b/app/containers/Woonplaats/index.js
@@ -35,8 +35,8 @@ WoonplaatsContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  data: makeSelectWoonplaatsData(),
-  status: makeSelectStatus(),
+  data: makeSelectWoonplaatsData,
+  status: makeSelectStatus,
 });
 
 const withConnect = connect(mapStateToProps);

--- a/app/containers/Woonplaats/saga.js
+++ b/app/containers/Woonplaats/saga.js
@@ -12,7 +12,7 @@ const { API_ROOT } = configuration;
 const WOONPLAATS_API = `${API_ROOT}bag/woonplaats/`;
 
 export function* fetchWoonplaatsData() {
-  const woonplaatsId = yield select(makeSelectWoonplaatsId());
+  const woonplaatsId = yield select(makeSelectWoonplaatsId);
 
   if (!woonplaatsId) {
     yield put(loadDataNoResults());

--- a/app/containers/Woonplaats/selectors.js
+++ b/app/containers/Woonplaats/selectors.js
@@ -3,25 +3,26 @@ import { createSelector } from 'reselect';
 import { makeSelectLocale } from 'containers/LanguageProvider/selectors';
 import { formatData } from 'utils';
 
-const selectWoonplaatsData = state => state.woonplaats;
+import { initialState } from './reducer';
 
-export const makeSelectWoonplaatsData = () =>
-  createSelector(
-    selectWoonplaatsData,
-    makeSelectLocale(),
-    (state, locale) => {
-      if (!state) {
-        return undefined;
-      }
+const selectWoonplaatsData = state => (state && state.woonplaats) || initialState;
 
-      const { data } = state;
+export const makeSelectWoonplaatsData = createSelector(
+  selectWoonplaatsData,
+  makeSelectLocale,
+  (state, locale) => {
+    if (!state) {
+      return undefined;
+    }
 
-      if (!data) {
-        return data;
-      }
+    const { data } = state;
 
-      const keys = ['naam', 'woonplaatsidentificatie'];
+    if (!data) {
+      return data;
+    }
 
-      return formatData({ data, keys, locale });
-    },
-  );
+    const keys = ['naam', 'woonplaatsidentificatie'];
+
+    return formatData({ data, keys, locale });
+  },
+);

--- a/app/shared/services/api/api.js
+++ b/app/shared/services/api/api.js
@@ -26,7 +26,7 @@ export function* authCall(url, params, authorizationToken) {
   if (authorizationToken) {
     headers.Authorization = `Bearer ${authorizationToken}`;
   } else {
-    const token = yield select(makeSelectAccessToken());
+    const token = yield select(makeSelectAccessToken);
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
@@ -47,7 +47,7 @@ export function* authPostCall(url, params) {
     'Content-Type': 'application/json',
   };
 
-  const token = yield select(makeSelectAccessToken());
+  const token = yield select(makeSelectAccessToken);
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }

--- a/app/shared/services/api/api.test.js
+++ b/app/shared/services/api/api.test.js
@@ -47,7 +47,7 @@ describe('api service', () => {
         },
       };
       const gen = authCall(url, params);
-      expect(gen.next().value).toEqual(select(makeSelectAccessToken())); // eslint-disable-line redux-saga/yield-effects
+      expect(gen.next().value).toEqual(select(makeSelectAccessToken)); // eslint-disable-line redux-saga/yield-effects
       expect(gen.next(token).value).toEqual(call(request, fullUrl, options)); // eslint-disable-line redux-saga/yield-effects
     });
 
@@ -60,7 +60,7 @@ describe('api service', () => {
         },
       };
       const gen = authCall(url, params);
-      expect(gen.next().value).toEqual(select(makeSelectAccessToken())); // eslint-disable-line redux-saga/yield-effects
+      expect(gen.next().value).toEqual(select(makeSelectAccessToken)); // eslint-disable-line redux-saga/yield-effects
       expect(gen.next().value).toEqual(call(request, fullUrl, options)); // eslint-disable-line redux-saga/yield-effects
     });
 
@@ -73,7 +73,7 @@ describe('api service', () => {
         },
       };
       const gen = authCall(url, undefined);
-      expect(gen.next().value).toEqual(select(makeSelectAccessToken())); // eslint-disable-line redux-saga/yield-effects
+      expect(gen.next().value).toEqual(select(makeSelectAccessToken)); // eslint-disable-line redux-saga/yield-effects
       expect(gen.next(token).value).toEqual(call(request, url, options)); // eslint-disable-line redux-saga/yield-effects
     });
 
@@ -103,7 +103,7 @@ describe('api service', () => {
         body: JSON.stringify(params),
       };
       const gen = authPostCall(url, params);
-      expect(gen.next().value).toEqual(select(makeSelectAccessToken())); // eslint-disable-line redux-saga/yield-effects
+      expect(gen.next().value).toEqual(select(makeSelectAccessToken)); // eslint-disable-line redux-saga/yield-effects
       expect(gen.next(token).value).toEqual(call(request, fullUrl, options)); // eslint-disable-line redux-saga/yield-effects
     });
 
@@ -117,7 +117,7 @@ describe('api service', () => {
         body: JSON.stringify(params),
       };
       const gen = authPostCall(url, params);
-      expect(gen.next().value).toEqual(select(makeSelectAccessToken())); // eslint-disable-line redux-saga/yield-effects
+      expect(gen.next().value).toEqual(select(makeSelectAccessToken)); // eslint-disable-line redux-saga/yield-effects
       expect(gen.next().value).toEqual(call(request, fullUrl, options)); // eslint-disable-line redux-saga/yield-effects
     });
   });

--- a/internals/templates/containers/App/tests/selectors.test.js
+++ b/internals/templates/containers/App/tests/selectors.test.js
@@ -9,6 +9,6 @@ describe('makeSelectLocation', () => {
     const mockedState = {
       route,
     };
-    expect(makeSelectLocation()(mockedState)).toEqual(route.location);
+    expect(makeSelectLocation(mockedState)).toEqual(route.location);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2578,6 +2578,38 @@
         "p-each-series": "^1.0.0"
       }
     },
+    "airbnb-prop-types": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "object.entries": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+          "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.12.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -2844,6 +2876,52 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.find": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        }
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.1",
@@ -5929,29 +6007,61 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz",
-      "integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.13.2.tgz",
+      "integrity": "sha512-h0neTuAAFfQUgEZ+PPHVIMDFJ9+CGafI8AjojNlSVh4Fd1pLDgtl2OeVkm4yKF7RSgzrPAwugq4JW8Jjo2iRJA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.8.0",
-        "function.prototype.name": "^1.1.0",
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
         "object.assign": "^4.1.0",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.5.2",
-        "react-test-renderer": "^16.0.0-0"
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "object.values": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+          "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.12.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz",
-      "integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
       "dev": true,
       "requires": {
+        "airbnb-prop-types": "^2.13.2",
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
-        "prop-types": "^15.6.2"
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "enzyme-to-json": {
@@ -13625,6 +13735,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "property-expr": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
@@ -14270,6 +14391,12 @@
       "requires": {
         "@redux-saga/core": "^1.0.2"
       }
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,14 +2841,12 @@
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-slice": {
       "version": "1.1.0",
@@ -7361,6 +7359,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.4.tgz",
+      "integrity": "sha1-zF0NiuHUbMmlVcJoL5EJd4WZNd8="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7532,6 +7535,11 @@
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
+    },
+    "fsm-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fsm-iterator/-/fsm-iterator-1.1.0.tgz",
+      "integrity": "sha1-M33kXeGesgV4jPAuOpVewgZ2Dew="
     },
     "fstream": {
       "version": "1.0.11",
@@ -8608,8 +8616,7 @@
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -10600,6 +10607,11 @@
         "lodash.get": "^4.4.2"
       }
     },
+    "json3": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.0.tgz",
+      "integrity": "sha1-Dp5/bF0nC3WJKa9Nb+/chL1m4lk="
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -11013,6 +11025,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -14392,6 +14409,19 @@
         "@redux-saga/core": "^1.0.2"
       }
     },
+    "redux-saga-test-plan": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/redux-saga-test-plan/-/redux-saga-test-plan-4.0.0-beta.3.tgz",
+      "integrity": "sha512-nOA2MsUHlp5JGlGhDo8IbVnKXIh1qLCE4vZE5rz1wvdXLMEk6F9QwfI1LbdaBT0XdrxjeI+JjeUAMZ5sgYfeTA==",
+      "requires": {
+        "core-js": "^2.4.1",
+        "fsm-iterator": "^1.1.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.ismatch": "^4.4.0",
+        "object-assign": "^4.1.0",
+        "util-inspect": "^0.1.8"
+      }
+    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -17702,6 +17732,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util-inspect": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/util-inspect/-/util-inspect-0.1.8.tgz",
+      "integrity": "sha1-KznbzS2SHy2EMJI8r/QPS1zqXbE=",
+      "requires": {
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "foreach": "2.0.4",
+        "indexof": "0.0.1",
+        "isarray": "0.0.1",
+        "json3": "3.3.0",
+        "object-keys": "0.5.0"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.5.0.tgz",
+          "integrity": "sha1-CeIR8+ADGK/E9ZLjbnzcENmtcpM="
+        }
+      }
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "dyson-generators": "^0.2.0",
     "dyson-image": "^0.2.0",
     "enzyme": "3.9.0",
-    "enzyme-adapter-react-16": "1.6.0",
+    "enzyme-adapter-react-16": "^1.13.2",
     "enzyme-to-json": "3.3.4",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "redux": "4.0.1",
     "redux-react-hook": "^3.0.4",
     "redux-saga": "1.0.2",
+    "redux-saga-test-plan": "^4.0.0-beta.3",
     "reselect": "4.0.0",
     "sanitize.css": "8.0.0",
     "styled-components": "4.2.0"


### PR DESCRIPTION
- Adds tests for the `AccommodationObjectPage` container
- Changes the way selectors are exported and fixes tests accordingly
- Sets correct initial states for selectors
- Adds `redux-saga-test-plan` package for easier saga testing