### PR TITLE
(Fix) Sentry CLI as global NPM package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --production=false \
         --no-progress \
         ci
 
-RUN npm install --unsafe-perm -g full-icu
+RUN npm install --unsafe-perm -g full-icu @sentry/cli
 RUN npm cache clean --force
 ENV NODE_ICU_DATA="/usr/local/lib/node_modules/full-icu"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ if (BRANCH == "master") {
     }
 
     node {
-        String VERSION = sh(script: 'npx sentry-cli releases propose-version', , returnStdout: true).trim()
+        String VERSION = sh(script: 'sentry-cli releases propose-version', , returnStdout: true).trim()
 
         stage("Sentry release") {
             tryStep "authenticate", {
@@ -83,8 +83,8 @@ if (BRANCH == "master") {
             }
 
             tryStep "create release", {
-                sh "npx sentry-cli releases new -p ${PROJECT} ${VERSION}"
-                sh "npx sentry-cli releases set-commits --auto ${VERSION}"
+                sh "sentry-cli releases new -p ${PROJECT} ${VERSION}"
+                sh "sentry-cli releases set-commits --auto ${VERSION}"
             }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,31 +1917,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@sentry/cli": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.45.0.tgz",
-      "integrity": "sha512-uwTMoX2XbWOMDM7kfG8puz3OzFi2UQzKvOMoVb/VBY1xFD+aaFwKgG0ZT2K+sRIZiU0srJac8yS0JrCd0qVDEg==",
-      "requires": {
-        "fs-copy-file-sync": "^1.1.1",
-        "https-proxy-agent": "^2.2.1",
-        "mkdirp": "^0.5.1",
-        "node-fetch": "^2.1.2",
-        "progress": "2.0.0",
-        "proxy-from-env": "^1.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        },
-        "progress": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
-        }
-      }
-    },
     "@sentry/core": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.4.0.tgz",
@@ -2658,14 +2633,6 @@
         "globby": "^9.0.0",
         "micromatch": "^3.1.3",
         "p-each-series": "^1.0.0"
-      }
-    },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
       }
     },
     "airbnb-prop-types": {
@@ -6208,21 +6175,6 @@
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
     },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-        }
-      }
-    },
     "es6-templates": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
@@ -7523,11 +7475,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
-    "fs-copy-file-sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
-      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ=="
-    },
     "fs-minipass": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
@@ -8430,30 +8377,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -13949,11 +13872,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@datapunt/asc-assets": "^0.6.3",
     "@datapunt/asc-ui": "^0.6.6",
     "@sentry/browser": "^5.4.0",
-    "@sentry/cli": "^1.45.0",
     "amsterdam-amaps": "^2.0.1",
     "amsterdam-stijl": "^3.0.5",
     "chalk": "2.4.2",


### PR DESCRIPTION
This PR:
- removes the `@sentry/cli` package from the project's dependencies
- changes the Dockerfile so that the aforementioned package is installed globally
- adjusts the command in the Jenkinsfile to reflect the global nature of the Sentry package