### PR TITLE
(Chore) Remove bearer token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com:
 COPY package.json package-lock.json /deploy/
 COPY internals /deploy/internals/
 
-# RUN npm config set registry https://nexus.data.amsterdam.nl/repository/npm-group/ && \
 RUN npm --production=false \
         --unsafe-perm \
         --verbose \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com:
 COPY package.json package-lock.json /deploy/
 COPY internals /deploy/internals/
 
+RUN npm install --unsafe-perm -g full-icu
+RUN npm cache clean --force
+ENV NODE_ICU_DATA="/usr/local/lib/node_modules/full-icu"
+
 RUN npm --production=false \
         --unsafe-perm \
         --verbose \
         --no-progress \
         ci
-
-RUN npm install --unsafe-perm -g full-icu
-RUN npm cache clean --force
-ENV NODE_ICU_DATA="/usr/local/lib/node_modules/full-icu"
 
 # Build dependencies
 COPY . /deploy/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,17 +74,6 @@ if (BRANCH == "master") {
 
     node {
         stage("Deploy to ACC") {
-            String GIT_COMMIT = sh(script: 'git log --pretty=format:"%H" | head -1', returnStdout: true)
-            String GIT_PREVIOUS_COMMIT = sh(script: 'git log --pretty=format:"%H" | head -2 | tail -1', returnStdout: true)
-
-            tryStep "Sentry release", {
-                sh label: '', script: "curl https://sentry.data.amsterdam.nl/api/0/organizations/sentry/releases/ \
-                    -X POST \
-                    -H 'Authorization: Bearer 81f08e755ede455a9a45285dba263f83745159255eb54f1c8a9a131ddbb4a8f0' \
-                    -H 'Content-Type: application/json' \
-                    -d '{\"version\": \"${GIT_COMMIT}\", \"projects\":[\"${PROJECT}\"]}'"
-            }
-
             tryStep "deployment", {
                 build job: 'Subtask_Openstack_Playbook',
                 parameters: [


### PR DESCRIPTION
Removes credentials from `Jenkinsfile`. Bearer token shouldn't be there in the first place and the token is invalid.