### PR TITLE
(Fix) Lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5746,6 +5746,14 @@
         "request": "2.88.0",
         "require-directory": "2.1.1",
         "serve-favicon": "2.5.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "dyson-generators": {
@@ -10970,9 +10978,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jest-localstorage-mock": "^2.4.0",
     "json2csv": "^4.5.0",
     "leaflet": "^1.4.0",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.14",
     "lodash.clonedeep": "^4.5.0",
     "minimist": "1.2.0",
     "mock-local-storage": "^1.1.8",


### PR DESCRIPTION
This PR fixes CVE-2019-10744
> Vulnerable versions: < 4.17.13
> Patched version: 4.17.13
> Affected versions of lodash are vulnerable to Prototype Pollution.
> The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.