### PR TITLE
(Fix) Jenkins env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY package.json package-lock.json /deploy/
 COPY internals /deploy/internals/
 
 RUN npm install --unsafe-perm -g full-icu
-RUN npm cache clean --force
 ENV NODE_ICU_DATA="/usr/local/lib/node_modules/full-icu"
 
 RUN npm --production=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ARG BUILD_NUMBER=0
 ARG GIT_COMMIT
 ENV GIT_COMMIT ${GIT_COMMIT}
 
-WORKDIR /deploy
-
 # Run updates and cleanup
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -20,6 +18,8 @@ RUN apt-get update && \
 #  Changing git URL because network is blocking git protocol...
 RUN git config --global url."https://".insteadOf git://
 RUN git config --global url."https://github.com/".insteadOf git@github.com:
+
+WORKDIR /deploy
 
 COPY package.json package-lock.json /deploy/
 COPY internals /deploy/internals/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ String PROJECT = "registraties"
 
 node {
     stage("Checkout") {
-        checkout scm
+        def scmVars = checkout(scm)
+        env.GIT_COMMIT = scmVars.GIT_COMMIT
     }
 
     stage("Lint") {


### PR DESCRIPTION
This PR:
- extracts the value from the latest Git commit from the `checkout` call and sets an env var with that value
- moves the `WORKDIR` declaration so that the Docker build is refreshed
- removes `npm cache clean` command since it doesn't reduce the container size and makes for faster builds