### PR TITLE
Fixes issues with reducer injection and non-deterministic behaviour.

### DIFF
--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -14,18 +14,18 @@ export default function configureStore(initialState = {}, history) {
 
   // If Redux Dev Tools and Saga Dev Tools Extensions are installed, enable them
   /* istanbul ignore next */
+  /* eslint-disable no-underscore-dangle */
   if (process.env.NODE_ENV !== 'production' && typeof window === 'object') {
-    /* eslint-disable no-underscore-dangle */
-    if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({});
-
     // NOTE: Uncomment the code below to restore support for Redux Saga
     // Dev Tools once it supports redux-saga version 1.x.x
     if (window.__SAGA_MONITOR_EXTENSION__)
       reduxSagaMonitorOptions = {
         sagaMonitor: window.__SAGA_MONITOR_EXTENSION__,
       };
-    /* eslint-enable */
   }
+
+  if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({});
+  /* eslint-enable */
 
   const sagaMiddleware = createSagaMiddleware(reduxSagaMonitorOptions);
 
@@ -40,6 +40,7 @@ export default function configureStore(initialState = {}, history) {
   const persistor = persistStore(store);
 
   // Extensions
+  store.persistor = persistor;
   store.runSaga = sagaMiddleware.run;
   store.injectedReducers = {}; // Reducer registry
   store.injectedSagas = {}; // Saga registry

--- a/app/utils/__tests__/reducerInjectors.test.js
+++ b/app/utils/__tests__/reducerInjectors.test.js
@@ -99,10 +99,18 @@ describe('reducer injectors', () => {
       expect(store.replaceReducer).toHaveBeenCalledTimes(2);
     });
 
-    it('should flush the persisted after injecting reducer', () => {
+    it('should flush the persisted state when injecting reducer', () => {
       store.persistor.flush = jest.fn();
       injectReducer('test', reducer);
       expect(store.persistor.flush).toHaveBeenCalledTimes(1);
+    });
+
+    it('should flush before replaceReducer is called', () => {
+      const callOrder = [];
+      store.persistor.flush = jest.fn().mockImplementation(() => callOrder.push('flush'));
+      store.replaceReducer = jest.fn().mockImplementation(() => callOrder.push('replaceReducer'));
+      injectReducer('test', reducer);
+      expect(callOrder).toEqual(['flush', 'replaceReducer']);
     });
   });
 });

--- a/app/utils/__tests__/reducerInjectors.test.js
+++ b/app/utils/__tests__/reducerInjectors.test.js
@@ -31,6 +31,7 @@ describe('reducer injectors', () => {
   describe('getInjectors', () => {
     beforeEach(() => {
       ({ store } = configureStore({}, memoryHistory));
+      store.persistor.flush = jest.fn();
     });
 
     it('should return injectors', () => {
@@ -51,6 +52,7 @@ describe('reducer injectors', () => {
   describe('injectReducer helper', () => {
     beforeEach(() => {
       ({ store } = configureStore({}, memoryHistory));
+      store.persistor.flush = jest.fn();
       injectReducer = injectReducerFactory(store, true);
     });
 
@@ -95,6 +97,12 @@ describe('reducer injectors', () => {
       injectReducer('test', identity);
 
       expect(store.replaceReducer).toHaveBeenCalledTimes(2);
+    });
+
+    it('should flush the persisted after injecting reducer', () => {
+      store.persistor.flush = jest.fn();
+      injectReducer('test', reducer);
+      expect(store.persistor.flush).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/utils/reducerInjectors.js
+++ b/app/utils/reducerInjectors.js
@@ -17,10 +17,9 @@ export function injectReducerFactory(store, isValid) {
     if (Reflect.has(store.injectedReducers, key) && store.injectedReducers[key] === reducer) return;
 
     // Flush the persisted state to localstorage before the store is replaced with a new reducer
-    store.persistor.flush().then(() => {
-      store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
-      store.replaceReducer(createReducer(store.injectedReducers));
-    });
+    store.persistor.flush();
+    store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
+    store.replaceReducer(createReducer(store.injectedReducers));
   };
 }
 

--- a/app/utils/reducerInjectors.js
+++ b/app/utils/reducerInjectors.js
@@ -16,8 +16,11 @@ export function injectReducerFactory(store, isValid) {
     // Check `store.injectedReducers[key] === reducer` for hot reloading when a key is the same but a reducer is different
     if (Reflect.has(store.injectedReducers, key) && store.injectedReducers[key] === reducer) return;
 
-    store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
-    store.replaceReducer(createReducer(store.injectedReducers));
+    // Flush the persisted state to localstorage before the store is replaced with a new reducer
+    store.persistor.flush().then(() => {
+      store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
+      store.replaceReducer(createReducer(store.injectedReducers));
+    });
   };
 }
 


### PR DESCRIPTION
Due to the non-deterministic behavior of the reducer injection/code splitting, the store hydrate and persist wasn't working as expected in acceptance.

In this PR:
- The store is now flushed before a reducer is injected. This is to make sure the latest state is always stored in the localstorage, and the state is hydrated correctly once createReducer is called
- Redux dev tools enabled for production, which is considered harmless and will help us debug this type of unexpected behavior.

Note:
Using code-splitting and redux-persist is not well documented. The documentation says _Code Splitting [coming soon]_. 
