### PR TITLE
Feature/bw 97 new search history

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -14,7 +14,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
-import { PersistGate } from 'redux-persist/integration/react';
 import history from 'utils/history';
 
 // Import root app
@@ -34,19 +33,17 @@ import { translationMessages } from './i18n';
 
 // Create redux store with history
 const initialState = {};
-const { store, persistor } = configureStore(initialState, history);
+const store = configureStore(initialState, history);
 const MOUNT_NODE = document.getElementById('app');
 
 const render = messages => {
   ReactDOM.render(
     <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <LanguageProvider messages={messages}>
-          <ConnectedRouter history={history}>
-            <App />
-          </ConnectedRouter>
-        </LanguageProvider>
-      </PersistGate>
+      <LanguageProvider messages={messages}>
+        <ConnectedRouter history={history}>
+          <App />
+        </ConnectedRouter>
+      </LanguageProvider>
     </Provider>,
     MOUNT_NODE,
   );

--- a/app/components/AccommodationObject/__tests__/AccommodationObject.test.js
+++ b/app/components/AccommodationObject/__tests__/AccommodationObject.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import AccommodationObject from '..';
 import * as styledComponents from '../styled';
 import configureStore from '../../../configureStore';
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 const intlProvider = new IntlProvider({ locale: 'nl', messages });
 const { intl } = intlProvider.getChildContext();

--- a/app/components/Search/__tests__/Search.test.js
+++ b/app/components/Search/__tests__/Search.test.js
@@ -9,7 +9,7 @@ import Search from '..';
 import configureStore from '../../../configureStore';
 import messages from '../../../translations/nl.json';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 const intlProvider = new IntlProvider({ locale: 'nl', messages });
 const { intl } = intlProvider.getChildContext();
 

--- a/app/components/Section/__tests__/Section.test.js
+++ b/app/components/Section/__tests__/Section.test.js
@@ -14,7 +14,7 @@ import pand from './pand.json';
 import subjectNP from './subjectNP.json';
 import vestiging from './vestiging.json';
 
-const { store } = configureStore({}, browserHistory);
+const store = configureStore({}, browserHistory);
 const intlProvider = new IntlProvider({ locale: 'nl', messages });
 const { intl } = intlProvider.getChildContext();
 

--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -5,7 +5,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import createSagaMiddleware from 'redux-saga';
-import { persistStore } from 'redux-persist';
 import createReducer from './reducers';
 
 export default function configureStore(initialState = {}, history) {
@@ -14,18 +13,18 @@ export default function configureStore(initialState = {}, history) {
 
   // If Redux Dev Tools and Saga Dev Tools Extensions are installed, enable them
   /* istanbul ignore next */
-  /* eslint-disable no-underscore-dangle */
+
   if (process.env.NODE_ENV !== 'production' && typeof window === 'object') {
+    /* eslint-disable no-underscore-dangle */
+    if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({});
     // NOTE: Uncomment the code below to restore support for Redux Saga
     // Dev Tools once it supports redux-saga version 1.x.x
     if (window.__SAGA_MONITOR_EXTENSION__)
       reduxSagaMonitorOptions = {
         sagaMonitor: window.__SAGA_MONITOR_EXTENSION__,
       };
+    /* eslint-enable */
   }
-
-  if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({});
-  /* eslint-enable */
 
   const sagaMiddleware = createSagaMiddleware(reduxSagaMonitorOptions);
 
@@ -37,10 +36,8 @@ export default function configureStore(initialState = {}, history) {
   const enhancers = [applyMiddleware(...middlewares)];
 
   const store = createStore(createReducer(), initialState, composeEnhancers(...enhancers));
-  const persistor = persistStore(store);
 
   // Extensions
-  store.persistor = persistor;
   store.runSaga = sagaMiddleware.run;
   store.injectedReducers = {}; // Reducer registry
   store.injectedSagas = {}; // Saga registry
@@ -53,5 +50,5 @@ export default function configureStore(initialState = {}, history) {
     });
   }
 
-  return { store, persistor };
+  return store;
 }

--- a/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
+++ b/app/containers/AccommodationObjectPage/__tests__/AccommodationObjectPage.test.js
@@ -10,7 +10,7 @@ import messages from '../../../translations/nl.json';
 import AccommodationObjectPageContainer, { AccommodationObjectPageComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/AccommodationObjectPage', () => {
   it('should have props from structured selector', () => {

--- a/app/containers/App/__tests__/App.test.js
+++ b/app/containers/App/__tests__/App.test.js
@@ -15,7 +15,7 @@ import GlobalStyles from '../../../global-styles';
 import messages from '../../../translations/nl.json';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 jest.mock('shared/services/auth/auth');
 

--- a/app/containers/CSVDownload/__tests__/CSVDownload.test.js
+++ b/app/containers/CSVDownload/__tests__/CSVDownload.test.js
@@ -16,7 +16,7 @@ import configureStore from '../../../configureStore';
 import nextProps from './nextProps.json';
 import exportData from './exportData.json';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 const { getDerivedStateFromProps, getParseConfig } = CSVDownloadContainer;
 
 jest.mock('json2csv');

--- a/app/containers/Gebied/__tests__/Gebied.test.js
+++ b/app/containers/Gebied/__tests__/Gebied.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import GebiedContainer, { GebiedContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/Gebied', () => {
   it('should have props from structured selector', () => {

--- a/app/containers/GlobalError/__tests__/GlobalError.test.js
+++ b/app/containers/GlobalError/__tests__/GlobalError.test.js
@@ -9,7 +9,7 @@ import GlobalError, { GlobalErrorContainer } from '..';
 import messages from '../messages';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/GlobalError', () => {
   afterEach(cleanup);

--- a/app/containers/Header/__tests__/Header.test.js
+++ b/app/containers/Header/__tests__/Header.test.js
@@ -11,7 +11,7 @@ import HeaderContainer, { HeaderContainerComponent } from '..';
 import messages from '../../../translations/nl.json';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 jest.mock('shared/services/auth/auth');
 

--- a/app/containers/KadastraalObject/__tests__/KadastraalObject.test.js
+++ b/app/containers/KadastraalObject/__tests__/KadastraalObject.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import KadastraalObjectContainer, { KadastraalObjectContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/KadastraalObject', () => {
   afterEach(cleanup);

--- a/app/containers/KadastraalSubjectNNP/__tests__/KadastraalSubjectNNP.test.js
+++ b/app/containers/KadastraalSubjectNNP/__tests__/KadastraalSubjectNNP.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import KadastraalSubjectNNPContainer, { KadastraalSubjectNNPContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/KadastraalSubjectNNP', () => {
   afterEach(cleanup);

--- a/app/containers/KadastraalSubjectNP/__tests__/KadastraalSubjectNP.test.js
+++ b/app/containers/KadastraalSubjectNP/__tests__/KadastraalSubjectNP.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import KadastraalSubjectNPContainer, { KadastraalSubjectNPContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/KadastraalSubjectNNP', () => {
   afterEach(cleanup);

--- a/app/containers/LanguageProvider/__tests__/LanguageProvider.test.js
+++ b/app/containers/LanguageProvider/__tests__/LanguageProvider.test.js
@@ -33,7 +33,7 @@ describe('<ConnectedLanguageProvider />', () => {
   let store;
 
   beforeAll(() => {
-    ({ store } = configureStore({}, browserHistory));
+    store = configureStore({}, browserHistory);
   });
 
   it('should render the default language messages', () => {

--- a/app/containers/Map/__tests__/Map.test.js
+++ b/app/containers/Map/__tests__/Map.test.js
@@ -7,7 +7,7 @@ import Map from 'components/Map/Loadable';
 import MapContainer from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/Map', () => {
   it('should have props from structured selector', () => {

--- a/app/containers/Nummeraanduiding/__tests__/Nummeraanduiding.test.js
+++ b/app/containers/Nummeraanduiding/__tests__/Nummeraanduiding.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import NummeraanduidingContainer, { NummeraanduidingContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/Nummeraanduiding', () => {
   afterEach(cleanup);

--- a/app/containers/OpenbareRuimte/__tests__/OpenbareRuimte.test.js
+++ b/app/containers/OpenbareRuimte/__tests__/OpenbareRuimte.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import OpenbareRuimteContainer, { OpenbareRuimteContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/OpenbareRuimte', () => {
   afterEach(cleanup);

--- a/app/containers/Pand/__tests__/Pand.test.js
+++ b/app/containers/Pand/__tests__/Pand.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import PandContainer, { PandContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/OpenbareRuimte', () => {
   afterEach(cleanup);

--- a/app/containers/Progress/__tests__/Progress.test.js
+++ b/app/containers/Progress/__tests__/Progress.test.js
@@ -11,7 +11,7 @@ import ProgressContainer, { ProgressContainerComponent } from '..';
 import messages from '../../../translations/nl.json';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 jest.mock('components/Progress', () => jest.requireActual('components/Progress'));
 

--- a/app/containers/Search/__tests__/Search.test.js
+++ b/app/containers/Search/__tests__/Search.test.js
@@ -15,7 +15,7 @@ import { makeSelectResults, makeSelectSuggestionResults } from '../selectors';
 import resultsSrc from './results.json';
 import resultsSuggestionsSrc from './resultsSuggestions.json';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 const intlObj = intl({ messages });
 const results = makeSelectResults({ search: { ...initialState, results: resultsSrc } });
 const suggestionResults = makeSelectSuggestionResults({ search: { ...initialState, results: resultsSuggestionsSrc } });

--- a/app/containers/Search/index.js
+++ b/app/containers/Search/index.js
@@ -7,6 +7,7 @@ import { injectIntl, intlShape } from 'react-intl';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
+import { pushSearchHistoryLocalStorage } from 'utils/searchHistory';
 import Search from 'components/Search';
 
 import { makeSelectResults, makeSelectSuggestionResults } from './selectors';
@@ -14,6 +15,7 @@ import reducer from './reducer';
 import saga from './saga';
 import { inputChanged, searchSelect } from './actions';
 import { pushSearchHistory } from '../SearchHistory/actions';
+
 import messages from './messages';
 
 export const SearchContainerComponent = props => {
@@ -54,7 +56,6 @@ export const SearchContainerComponent = props => {
     event.persist();
 
     const { target } = event;
-
     props.onChange(target.value);
   };
 
@@ -67,6 +68,8 @@ export const SearchContainerComponent = props => {
     } = event;
 
     props.pushSearchHistory({ ...dataset, text });
+    pushSearchHistoryLocalStorage({ ...dataset, text });
+
     props.onSearchSelect({ ...dataset });
     inputRef.current.value = text;
   };

--- a/app/containers/SearchHistory/reducer.js
+++ b/app/containers/SearchHistory/reducer.js
@@ -1,11 +1,10 @@
 import produce from 'immer';
-import { uniqBy } from 'lodash';
-
+import { getSearchHistoryLocalStorage, getCleanSearchHistory } from 'utils/searchHistory';
 import { PUSH_SEARCH_HISTORY } from './constants';
 
 // The initial state of the App
 export const initialState = {
-  searchHistory: [],
+  searchHistory: getSearchHistoryLocalStorage(),
 };
 
 /* eslint-disable default-case, no-param-reassign */
@@ -13,7 +12,7 @@ export default (state = initialState, action) =>
   produce(state, draft => {
     switch (action.type) {
       case PUSH_SEARCH_HISTORY:
-        draft.searchHistory = uniqBy([action.payload, ...state.searchHistory], 'text').slice(0, 10);
+        draft.searchHistory = getCleanSearchHistory(action.payload, state.searchHistory);
         break;
     }
   });

--- a/app/containers/Summary/__tests__/Summary.test.js
+++ b/app/containers/Summary/__tests__/Summary.test.js
@@ -9,7 +9,7 @@ import messages from '../../../translations/nl.json';
 import SummaryContainer from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/Summary', () => {
   it('should have props from structured selector', () => {

--- a/app/containers/TOC/__tests__/TOC.test.js
+++ b/app/containers/TOC/__tests__/TOC.test.js
@@ -9,7 +9,7 @@ import messages from '../../../translations/nl.json';
 import TOCContainer from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 describe('containers/TOC', () => {
   it('should have props from structured selector', () => {
     const tree = mount(

--- a/app/containers/Woonplaats/__tests__/Woonplaats.test.js
+++ b/app/containers/Woonplaats/__tests__/Woonplaats.test.js
@@ -11,7 +11,7 @@ import messages from '../../../translations/nl.json';
 import WoonplaatsContainer, { WoonplaatsContainerComponent } from '..';
 import configureStore from '../../../configureStore';
 
-const { store } = configureStore({}, history);
+const store = configureStore({}, history);
 
 describe('containers/Woonplaats', () => {
   afterEach(cleanup);

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -4,8 +4,6 @@
 
 import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
-import { persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import history from 'utils/history';
 import globalReducer from 'containers/App/reducer';
@@ -24,13 +22,5 @@ export default function createReducer(injectedReducers = {}) {
     ...injectedReducers,
   });
 
-  const persistConfig = {
-    key: 'root',
-    storage,
-    whitelist: ['searchHistory'],
-  };
-
-  const persistedReducer = persistReducer(persistConfig, rootReducer);
-
-  return persistedReducer;
+  return rootReducer;
 }

--- a/app/tests/store.test.js
+++ b/app/tests/store.test.js
@@ -9,7 +9,7 @@ describe('configureStore', () => {
   let store;
 
   beforeAll(() => {
-    ({ store } = configureStore({}, browserHistory));
+    store = configureStore({}, browserHistory);
   });
 
   describe('injectedReducers', () => {

--- a/app/utils/__tests__/injectReducer.test.js
+++ b/app/utils/__tests__/injectReducer.test.js
@@ -27,7 +27,7 @@ describe('injectReducer decorator', () => {
   });
 
   beforeEach(() => {
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     injectors = {
       injectReducer: jest.fn(),
     };
@@ -76,7 +76,7 @@ describe('useInjectReducer hook', () => {
       injectReducer: jest.fn(),
     };
     reducerInjectors.default = jest.fn().mockImplementation(() => injectors);
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     ComponentWithReducer = () => {
       useInjectReducer({ key: 'test', reducer });
       return null;

--- a/app/utils/__tests__/injectSaga.test.js
+++ b/app/utils/__tests__/injectSaga.test.js
@@ -30,7 +30,7 @@ describe('injectSaga decorator', () => {
   });
 
   beforeEach(() => {
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     injectors = {
       injectSaga: jest.fn(),
       ejectSaga: jest.fn(),
@@ -97,7 +97,7 @@ describe('useInjectSaga hook', () => {
   });
 
   beforeEach(() => {
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     injectors = {
       injectSaga: jest.fn(),
       ejectSaga: jest.fn(),

--- a/app/utils/__tests__/reducerInjectors.test.js
+++ b/app/utils/__tests__/reducerInjectors.test.js
@@ -30,8 +30,7 @@ describe('reducer injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
-      store.persistor.flush = jest.fn();
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -51,8 +50,7 @@ describe('reducer injectors', () => {
 
   describe('injectReducer helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
-      store.persistor.flush = jest.fn();
+      store = configureStore({}, memoryHistory);
       injectReducer = injectReducerFactory(store, true);
     });
 
@@ -97,20 +95,6 @@ describe('reducer injectors', () => {
       injectReducer('test', identity);
 
       expect(store.replaceReducer).toHaveBeenCalledTimes(2);
-    });
-
-    it('should flush the persisted state when injecting reducer', () => {
-      store.persistor.flush = jest.fn();
-      injectReducer('test', reducer);
-      expect(store.persistor.flush).toHaveBeenCalledTimes(1);
-    });
-
-    it('should flush before replaceReducer is called', () => {
-      const callOrder = [];
-      store.persistor.flush = jest.fn().mockImplementation(() => callOrder.push('flush'));
-      store.replaceReducer = jest.fn().mockImplementation(() => callOrder.push('replaceReducer'));
-      injectReducer('test', reducer);
-      expect(callOrder).toEqual(['flush', 'replaceReducer']);
     });
   });
 });

--- a/app/utils/__tests__/sagaInjectors.test.js
+++ b/app/utils/__tests__/sagaInjectors.test.js
@@ -25,7 +25,7 @@ describe('injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -46,7 +46,7 @@ describe('injectors', () => {
 
   describe('ejectSaga helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });
@@ -121,7 +121,7 @@ describe('injectors', () => {
 
   describe('injectSaga helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });

--- a/app/utils/__tests__/searchHistory.test.js
+++ b/app/utils/__tests__/searchHistory.test.js
@@ -1,0 +1,76 @@
+/**
+ * Test search history utility functions
+ */
+import 'jest-localstorage-mock';
+import { getCleanSearchHistory, pushSearchHistoryLocalStorage, getSearchHistoryLocalStorage } from '../searchHistory';
+
+describe('searchHistory utils', () => {
+  describe('getCleanSearchHistory', () => {
+    it('Should return a clean search history of max 10 item', () => {
+      const searchHistory = [];
+      const newSearch = {
+        vboId: 'newID',
+        text: 'new',
+      };
+
+      for (let i = 0; i < 20; i += 1) {
+        searchHistory.push({
+          vboId: 'fooVboId',
+          text: `fooLabel-${i}`,
+        });
+      }
+
+      const cleanSearchHistory = getCleanSearchHistory(newSearch, searchHistory);
+      expect(cleanSearchHistory.length).toBe(10);
+    });
+
+    it('Should return a clean search history with nu duplicate items', () => {
+      const searchHistory = [];
+      const newSearch = {
+        vboId: 'newID',
+        text: 'new',
+      };
+
+      for (let i = 0; i < 20; i += 1) {
+        searchHistory.push(newSearch);
+      }
+
+      const cleanSearchHistory = getCleanSearchHistory(newSearch, searchHistory);
+      expect(cleanSearchHistory.length).toBe(1);
+      expect(cleanSearchHistory).toStrictEqual([newSearch]);
+    });
+  });
+  describe('getSearchHistoryLocalStorage function', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('Should return an empty list if localstorage is empty', () => {
+      const searchHistory = getSearchHistoryLocalStorage();
+      expect(searchHistory).toStrictEqual([]);
+    });
+
+    it('Should return the search history list from localstorage', () => {
+      const stringSearchHistory =
+        '[{"vboId":"0363010000758829","text":"Oudezijds Achterburgwal 2"},{"vboId":"0363010001009652","text":"Oudezijds Achterburgwal 3A"},{"vboId":"0363010000819482","text":"Stadionweg 30"}]';
+      localStorage.setItem('searchHistory', stringSearchHistory);
+
+      const searchHistory = getSearchHistoryLocalStorage();
+      expect(searchHistory).toStrictEqual(JSON.parse(stringSearchHistory));
+    });
+  });
+
+  describe('pushSearchHistoryLocalStorage function', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('Should add a new search to localstorage', () => {
+      pushSearchHistoryLocalStorage({ vboId: '0363010000758829', text: 'Oudezijds Achterburgwal 2' });
+      const searchHistory = localStorage.getItem('searchHistory');
+
+      const stringSearchHistory = '[{"vboId":"0363010000758829","text":"Oudezijds Achterburgwal 2"}]';
+      expect(searchHistory).toStrictEqual(stringSearchHistory);
+    });
+  });
+});

--- a/app/utils/__tests__/searchHistory.test.js
+++ b/app/utils/__tests__/searchHistory.test.js
@@ -2,7 +2,12 @@
  * Test search history utility functions
  */
 import 'jest-localstorage-mock';
-import { getCleanSearchHistory, pushSearchHistoryLocalStorage, getSearchHistoryLocalStorage } from '../searchHistory';
+import {
+  getCleanSearchHistory,
+  pushSearchHistoryLocalStorage,
+  getSearchHistoryLocalStorage,
+  SEARCH_HISTORY_STORAGE_KEY,
+} from '../searchHistory';
 
 describe('searchHistory utils', () => {
   describe('getCleanSearchHistory', () => {
@@ -53,10 +58,24 @@ describe('searchHistory utils', () => {
     it('Should return the search history list from localstorage', () => {
       const stringSearchHistory =
         '[{"vboId":"0363010000758829","text":"Oudezijds Achterburgwal 2"},{"vboId":"0363010001009652","text":"Oudezijds Achterburgwal 3A"},{"vboId":"0363010000819482","text":"Stadionweg 30"}]';
-      localStorage.setItem('searchHistory', stringSearchHistory);
+      localStorage.setItem(SEARCH_HISTORY_STORAGE_KEY, stringSearchHistory);
 
       const searchHistory = getSearchHistoryLocalStorage();
       expect(searchHistory).toStrictEqual(JSON.parse(stringSearchHistory));
+    });
+
+    it('Should return an empty list if the localstorage searchHistory is broken', () => {
+      const stringSearchHistory = '[]{';
+      localStorage.setItem(SEARCH_HISTORY_STORAGE_KEY, stringSearchHistory);
+
+      expect(getSearchHistoryLocalStorage()).toStrictEqual([]);
+    });
+
+    it('Should reset localstorage searchHistory if it is broken', () => {
+      const stringSearchHistory = '[]{';
+      localStorage.setItem(SEARCH_HISTORY_STORAGE_KEY, stringSearchHistory);
+      getSearchHistoryLocalStorage();
+      expect(localStorage.getItem(SEARCH_HISTORY_STORAGE_KEY)).toBeNull();
     });
   });
 
@@ -67,7 +86,7 @@ describe('searchHistory utils', () => {
 
     it('Should add a new search to localstorage', () => {
       pushSearchHistoryLocalStorage({ vboId: '0363010000758829', text: 'Oudezijds Achterburgwal 2' });
-      const searchHistory = localStorage.getItem('searchHistory');
+      const searchHistory = localStorage.getItem(SEARCH_HISTORY_STORAGE_KEY);
 
       const stringSearchHistory = '[{"vboId":"0363010000758829","text":"Oudezijds Achterburgwal 2"}]';
       expect(searchHistory).toStrictEqual(stringSearchHistory);

--- a/app/utils/reducerInjectors.js
+++ b/app/utils/reducerInjectors.js
@@ -16,8 +16,6 @@ export function injectReducerFactory(store, isValid) {
     // Check `store.injectedReducers[key] === reducer` for hot reloading when a key is the same but a reducer is different
     if (Reflect.has(store.injectedReducers, key) && store.injectedReducers[key] === reducer) return;
 
-    // Flush the persisted state to localstorage before the store is replaced with a new reducer
-    store.persistor.flush();
     store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
     store.replaceReducer(createReducer(store.injectedReducers));
   };

--- a/app/utils/searchHistory.js
+++ b/app/utils/searchHistory.js
@@ -1,0 +1,22 @@
+import { uniqBy } from 'lodash';
+
+const SEARCH_HISTORY_STORAGE_KEY = 'searchHistory';
+const MAX_SEARCH_ITEMS = 10;
+
+export const getCleanSearchHistory = (newSearch, searchHistory) =>
+  uniqBy([newSearch, ...searchHistory], 'text').slice(0, MAX_SEARCH_ITEMS);
+
+export const pushSearchHistoryLocalStorage = newSearch => {
+  const searchHistory = getSearchHistoryLocalStorage();
+
+  const newSearchHistory = getCleanSearchHistory(newSearch, searchHistory);
+  const newSearchHistoryString = JSON.stringify(newSearchHistory);
+
+  localStorage.setItem(SEARCH_HISTORY_STORAGE_KEY, newSearchHistoryString);
+};
+
+export const getSearchHistoryLocalStorage = () => {
+  const searchHistoryString = localStorage.getItem(SEARCH_HISTORY_STORAGE_KEY);
+  const searchHistory = JSON.parse(searchHistoryString) || [];
+  return searchHistory;
+};

--- a/app/utils/searchHistory.js
+++ b/app/utils/searchHistory.js
@@ -1,6 +1,6 @@
 import { uniqBy } from 'lodash';
 
-const SEARCH_HISTORY_STORAGE_KEY = 'searchHistory';
+export const SEARCH_HISTORY_STORAGE_KEY = 'searchHistory';
 const MAX_SEARCH_ITEMS = 10;
 
 export const getCleanSearchHistory = (newSearch, searchHistory) =>
@@ -17,6 +17,12 @@ export const pushSearchHistoryLocalStorage = newSearch => {
 
 export const getSearchHistoryLocalStorage = () => {
   const searchHistoryString = localStorage.getItem(SEARCH_HISTORY_STORAGE_KEY);
-  const searchHistory = JSON.parse(searchHistoryString) || [];
-  return searchHistory;
+  try {
+    const searchHistory = JSON.parse(searchHistoryString) || [];
+    return searchHistory;
+  } catch (error) {
+    console.error('Invalid searchHistory in localstorage');
+    localStorage.removeItem(SEARCH_HISTORY_STORAGE_KEY);
+  }
+  return [];
 };

--- a/internals/templates/app.js
+++ b/internals/templates/app.js
@@ -35,7 +35,7 @@ import { translationMessages } from './i18n';
 
 // Create redux store with history
 const initialState = {};
-const { store } = configureStore(initialState, history);
+const store = configureStore(initialState, history);
 const MOUNT_NODE = document.getElementById('app');
 
 const render = messages => {

--- a/internals/templates/configureStore.js
+++ b/internals/templates/configureStore.js
@@ -5,7 +5,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import createSagaMiddleware from 'redux-saga';
-import { persistStore } from 'redux-persist';
 import createReducer from './reducers';
 
 export default function configureStore(initialState = {}, history) {
@@ -37,7 +36,6 @@ export default function configureStore(initialState = {}, history) {
   const enhancers = [applyMiddleware(...middlewares)];
 
   const store = createStore(createReducer(), initialState, composeEnhancers(...enhancers));
-  const persistor = persistStore(store);
 
   // Extensions
   store.runSaga = sagaMiddleware.run;
@@ -52,5 +50,5 @@ export default function configureStore(initialState = {}, history) {
     });
   }
 
-  return { store, persistor };
+  return store;
 }

--- a/internals/templates/utils/tests/injectReducer.test.js
+++ b/internals/templates/utils/tests/injectReducer.test.js
@@ -26,7 +26,7 @@ describe('injectReducer decorator', () => {
   });
 
   beforeEach(() => {
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     injectors = {
       injectReducer: jest.fn(),
     };

--- a/internals/templates/utils/tests/injectSaga.test.js
+++ b/internals/templates/utils/tests/injectSaga.test.js
@@ -28,7 +28,7 @@ describe('injectSaga decorator', () => {
   });
 
   beforeEach(() => {
-    ({ store } = configureStore({}, memoryHistory));
+    store = configureStore({}, memoryHistory);
     injectors = {
       injectSaga: jest.fn(),
       ejectSaga: jest.fn(),

--- a/internals/templates/utils/tests/reducerInjectors.test.js
+++ b/internals/templates/utils/tests/reducerInjectors.test.js
@@ -30,7 +30,7 @@ describe('reducer injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -50,7 +50,7 @@ describe('reducer injectors', () => {
 
   describe('injectReducer helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
       injectReducer = injectReducerFactory(store, true);
     });
 

--- a/internals/templates/utils/tests/sagaInjectors.test.js
+++ b/internals/templates/utils/tests/sagaInjectors.test.js
@@ -21,7 +21,7 @@ describe('injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -42,7 +42,7 @@ describe('injectors', () => {
 
   describe('ejectSaga helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });
@@ -117,7 +117,7 @@ describe('injectors', () => {
 
   describe('injectSaga helper', () => {
     beforeEach(() => {
-      ({ store } = configureStore({}, memoryHistory));
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6201,8 +6201,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "console-stream": {
       "version": "0.1.1",
@@ -13824,7 +13823,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -13834,8 +13832,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -16417,11 +16414,6 @@
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
-    },
-    "redux-persist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
-      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
     },
     "redux-react-hook": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "redux": "4.0.1",
-    "redux-persist": "^6.0.0",
     "redux-react-hook": "^3.0.4",
     "redux-saga": "1.0.2",
     "reselect": "4.0.0",


### PR DESCRIPTION
After debugging and refactoring, I've come to the conclusion that redux-persist isn't compatible with dynamic reducer injection. That's why I've decided to implement an alternative solution.

This PR reverts all the changes made for integrating redux-persist. It also implements some basic functionality for adding searchHistory through the localstorage. This has been tested on all browsers and works, and seems to be a more robust solution for this project.