### PR TITLE
Fix/bw 139 font rendering

### DIFF
--- a/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
+++ b/app/components/AccommodationObject/__tests__/__snapshots__/AccommodationObject.test.js.snap
@@ -1075,7 +1075,8 @@ exports[`AccommodationObject should render without problems 2`] = `
 }
 
 .c1 {
-  font-weight: bold;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
 }
 
 .c0 {
@@ -1232,7 +1233,8 @@ exports[`AccommodationObject should render without problems 2`] = `
 
 exports[`styled components should match the snapshot 1`] = `
 .c0 {
-  font-weight: bold;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
 }
 
 @media print {

--- a/app/components/AccommodationObject/styled.js
+++ b/app/components/AccommodationObject/styled.js
@@ -49,7 +49,6 @@ export const Wrapper = styled.div`
 `;
 
 export const Key = styled.strong`
-  font-weight: bold;
   margin-top: 20px;
 `;
 
@@ -65,7 +64,8 @@ export const Textarea = styled.textarea`
 `;
 
 export const Label = styled.label`
-  font-weight: bold;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
 
   @media print {
     display: block;

--- a/app/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/app/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -219,6 +219,11 @@ exports[`Header matches the snapshot 1`] = `
   max-width: 1080px;
 }
 
+.c5 a {
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
+}
+
 .c0 {
   position: relative;
   z-index: 2;
@@ -478,7 +483,7 @@ exports[`Header matches the snapshot 2`] = `
       id="header"
     >
       <header
-        class="sc-gzVnrw sc-TOsTZ jnQENo Header__StyledHeader-sc-15eqjjx-0 NarrX"
+        class="sc-gzVnrw sc-TOsTZ jnQENo Header__StyledHeader-sc-15eqjjx-0 bWufNh"
       >
         <h1
           class="sc-ksYbfQ jNsosU"

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -10,6 +10,10 @@ import messages from './messages';
 
 const StyledHeader = styled(HeaderComponent)`
   max-width: 1080px;
+  a {
+    font-family: Avenir Next LT W01 Demi;
+    font-weight: 400;
+  }
 `;
 
 const HeaderWrapper = styled.div`

--- a/app/components/Link/__tests__/__snapshots__/Link.test.js.snap
+++ b/app/components/Link/__tests__/__snapshots__/Link.test.js.snap
@@ -58,6 +58,7 @@ exports[`Link matches the snapshot 1`] = `
 
 .c2 {
   padding: 0 !important;
+  font-weight: 400;
 }
 
 .c2:focus {

--- a/app/components/Link/index.js
+++ b/app/components/Link/index.js
@@ -6,6 +6,7 @@ import { ChevronRight } from '@datapunt/asc-assets';
 
 const StyledT = styled(T)`
   padding: 0 !important;
+  font-weight: 400;
 
   &:focus {
     outline: 4px solid #ffc90e !important;

--- a/app/components/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/app/components/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -38,8 +38,9 @@ exports[`Search matches the snapshot 1`] = `
 
 .c6 {
   font-size: 18px;
-  font-weight: bold;
   line-height: 25px;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
   margin-bottom: 10px;
 }
 
@@ -291,6 +292,7 @@ exports[`Search should render results 1`] = `
 
 .c14 {
   padding: 0 !important;
+  font-weight: 400;
 }
 
 .c14:focus {
@@ -342,8 +344,9 @@ exports[`Search should render results 1`] = `
 
 .c6 {
   font-size: 18px;
-  font-weight: bold;
   line-height: 25px;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
   margin-bottom: 10px;
 }
 

--- a/app/components/Search/index.js
+++ b/app/components/Search/index.js
@@ -19,8 +19,9 @@ const Form = styled.form`
 
 const Label = styled.label`
   font-size: 18px;
-  font-weight: bold;
   line-height: 25px;
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
   margin-bottom: 10px;
 `;
 

--- a/app/components/Suggest/__tests__/__snapshots__/Suggest.test.js.snap
+++ b/app/components/Suggest/__tests__/__snapshots__/Suggest.test.js.snap
@@ -58,6 +58,7 @@ exports[`Suggest matches the snapshot 1`] = `
 
 .c4 {
   padding: 0 !important;
+  font-weight: 400;
 }
 
 .c4:focus {

--- a/app/components/Summary/index.js
+++ b/app/components/Summary/index.js
@@ -9,6 +9,7 @@ import LoadingIndicator from 'components/LoadingIndicator';
 
 const Dt = styled.dt`
   font-family: Avenir Next LT W01 Demi;
+  font-weight: 400;
 `;
 
 const Dd = styled.dd`

--- a/app/components/TOC/__tests__/__snapshots__/TOC.test.js.snap
+++ b/app/components/TOC/__tests__/__snapshots__/TOC.test.js.snap
@@ -63,6 +63,7 @@ exports[`TOC matches the snapshot 1`] = `
 
 .c4 {
   padding: 0 !important;
+  font-weight: 400;
 }
 
 .c4:focus {

--- a/app/global-styles.js
+++ b/app/global-styles.js
@@ -30,6 +30,11 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.4em !important;
   }
 
+  h1, h2, h3, h4, h5, h6, h7, strong {
+    font-family: Avenir Next LT W01 Demi;
+    font-weight: 400;
+  }
+
   ul li {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Fixes font rendering for headers and strong/bold labels.
These now use Avenir Next LT W01 Demi, without additional font-weights. 
Adding additional font-weights makes the text thicker, which is not necessary if you're already using the 'Demi' font variation.