### PR TITLE
Fix clicking links using delay

### DIFF
--- a/app/containers/Search/__tests__/Search.test.js
+++ b/app/containers/Search/__tests__/Search.test.js
@@ -217,7 +217,7 @@ describe('containers/Search', () => {
       }),
     );
 
-    expect(document.getElementsByClassName('links')).toHaveLength(linksLength);
+    expect(document.getElementsByClassName('links')).toHaveLength(0);
 
     // put focus back on input element
     fireEvent(
@@ -250,7 +250,7 @@ describe('containers/Search', () => {
       }),
     );
 
-    expect(document.getElementsByClassName('links')).toHaveLength(linksLength);
+    expect(document.getElementsByClassName('links')).toHaveLength(0);
   });
 
   it('should fill the search field with the clicked suggestion', () => {

--- a/app/containers/Search/index.js
+++ b/app/containers/Search/index.js
@@ -4,7 +4,7 @@ import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
-import { debounce } from 'lodash';
+import { debounce, delay } from 'lodash';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
@@ -38,9 +38,7 @@ export const SearchContainerComponent = props => {
 
   const onFocusOut = event => {
     const { relatedTarget } = event;
-    // Fix for browser where relatedTarget is `null`
-    // Maybe a better overall solution would be to use React's `onFocus` and `onBlur` vs. refs + focusout
-    if (relatedTarget == null) return;
+
     const { current: input } = inputRef;
     const { current: suggest } = suggestRef;
 
@@ -48,7 +46,16 @@ export const SearchContainerComponent = props => {
     const blurFromSuggest = !suggest || (suggest !== null && !suggest.contains(relatedTarget));
 
     if (blurFromInput && blurFromSuggest) {
-      setShowSuggest(false);
+      // Fix for Safari, Safari iOS
+      // ==========================
+      // In Safari the focusout event is triggered before
+      // the click is handled. And because the links are hidden,
+      // they are not followed.
+      // Maybe a better overall solution would be
+      // to use React's `onFocus` and `onBlur` vs. refs + focusout.
+      // Cause this solution is still subject to a possible
+      // race condition, although 200ms seems more than fine.
+      delay(() => setShowSuggest(false), 200);
     }
   };
 

--- a/app/containers/Search/index.js
+++ b/app/containers/Search/index.js
@@ -4,7 +4,7 @@ import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { injectIntl, intlShape } from 'react-intl';
-import { debounce, delay } from 'lodash';
+import { debounce } from 'lodash';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
@@ -36,6 +36,13 @@ export const SearchContainerComponent = props => {
     };
   }, []);
 
+  // Bug in Safari, Safari iOS
+  // ==========================
+  // In Safari the focusout event is triggered before
+  // the click is handled. And because the links are hidden,
+  // they are not followed.
+  // Maybe a better overall solution would be
+  // to use React's `onFocus` and `onBlur` vs. refs + focusout.
   const onFocusOut = event => {
     const { relatedTarget } = event;
 
@@ -46,16 +53,7 @@ export const SearchContainerComponent = props => {
     const blurFromSuggest = !suggest || (suggest !== null && !suggest.contains(relatedTarget));
 
     if (blurFromInput && blurFromSuggest) {
-      // Fix for Safari, Safari iOS
-      // ==========================
-      // In Safari the focusout event is triggered before
-      // the click is handled. And because the links are hidden,
-      // they are not followed.
-      // Maybe a better overall solution would be
-      // to use React's `onFocus` and `onBlur` vs. refs + focusout.
-      // Cause this solution is still subject to a possible
-      // race condition, although 200ms seems more than fine.
-      delay(() => setShowSuggest(false), 200);
+      setShowSuggest(false);
     }
   };
 


### PR DESCRIPTION
Previous solution (checking relatedTarget == null) did not seem to work.